### PR TITLE
Added team management capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ A Model Context Protocol (MCP) server that provides seamless integration with Ji
 ## Features
 
 - **Issue Management**: Search, create, update, and transition Jira issues
+- **Team Management**: Define teams with multiple members and assign them to issues as watchers
+- **Component Aliases**: Use short, memorable aliases instead of long component names
+- **Watcher Management**: Add, remove, and list watchers on issues
 - **Issue Linking**: Create links between issues with different relationship types (blocks, relates to, etc.)
 - **Project Access**: List and browse Jira projects and components
 - **Comments**: Add comments to issues with security levels
@@ -61,7 +64,15 @@ JIRA_ACCESS_TOKEN=your-personal-access-token
 JIRA_VERIFY_SSL=true
 JIRA_TIMEOUT=30
 JIRA_MAX_RESULTS=100
+
+# Optional: Configure teams (JSON format with usernames, NOT email addresses)
+JIRA_TEAMS={"frontend": ["alice", "bob"], "backend": ["charlie", "david"], "devops": ["eve"]}
+
+# Optional: Configure component aliases (JSON format mapping aliases to actual component names)
+JIRA_COMPONENT_ALIASES={"ui": "User Interface", "be": "Backend Services", "infra": "Infrastructure"}
 ```
+
+**Note:** Team member names must be Jira usernames, not email addresses.
 
 ### Jira Cloud Setup
 
@@ -243,6 +254,12 @@ Once connected, you can ask Claude:
 - "Log 2 hours of work on issue PROJ-123 for debugging the login bug"
 - "Link issue PROJ-123 to PROJ-456 with a 'blocks' relationship"
 - "Show me all available link types for this Jira instance"
+- "Assign the frontend team to issue PROJ-123"
+- "Create a new issue and assign it to the backend team"
+- "Who is watching issue PROJ-123?"
+- "Add alice as a watcher to issue PROJ-456"
+- **"Find all issues assigned to the frontend team"**
+- **"Show me open issues assigned to the backend team"**
 
 ### Gemini CLI
 
@@ -335,6 +352,21 @@ Search for issues using JQL (Jira Query Language):
 "created >= -7d AND project in (PROJ1, PROJ2)"
 ```
 
+### `search_issues_by_team`
+Search for issues assigned to any member of a team:
+```python
+search_issues_by_team(
+    team_name="frontend",
+    project_key="PROJ",  # Optional
+    status="In Progress"  # Optional
+)
+```
+
+This automatically generates a JQL query like:
+```
+project = PROJ AND (assignee = "alice" OR assignee = "bob") AND status = "In Progress"
+```
+
 ### `get_issue`
 Get detailed information about a specific issue:
 ```python
@@ -418,6 +450,99 @@ get_projects()
 Get components for a specific project:
 ```python
 get_project_components(project_key="PROJ")
+```
+
+### Team Management Tools
+
+#### `list_teams`
+List all configured teams and their members:
+```python
+list_teams()
+```
+
+#### `add_team`
+Add or update a team configuration:
+```python
+add_team(
+    team_name="frontend",
+    members=["alice", "bob", "charlie"]
+)
+```
+
+#### `remove_team`
+Remove a team configuration:
+```python
+remove_team(team_name="frontend")
+```
+
+#### `assign_team_to_issue`
+Assign a team to an issue by adding all team members as watchers:
+```python
+assign_team_to_issue(
+    issue_key="PROJ-123",
+    team_name="frontend"
+)
+```
+
+Note: When creating issues, you can also use the `team` parameter to automatically add team members as watchers:
+```python
+create_issue(
+    project_key="PROJ",
+    summary="Fix login bug",
+    description="Users cannot log in",
+    issue_type="Bug",
+    priority="High",
+    team="frontend"  # All frontend team members will be added as watchers
+)
+```
+
+### Watcher Management Tools
+
+#### `get_issue_watchers`
+Get all watchers for an issue:
+```python
+get_issue_watchers(issue_key="PROJ-123")
+```
+
+#### `add_watcher_to_issue`
+Add a single watcher to an issue:
+```python
+add_watcher_to_issue(
+    issue_key="PROJ-123",
+    username="alice"
+)
+```
+
+#### `remove_watcher_from_issue`
+Remove a watcher from an issue:
+```python
+remove_watcher_from_issue(
+    issue_key="PROJ-123",
+    username="alice"
+)
+```
+
+### Component Alias Management Tools
+
+#### `list_component_aliases`
+List all configured component aliases:
+```python
+list_component_aliases()
+```
+
+#### `add_component_alias`
+Add or update a component alias:
+```python
+add_component_alias(
+    alias="ui",
+    component_name="User Interface"
+)
+```
+
+#### `remove_component_alias`
+Remove a component alias:
+```python
+remove_component_alias(alias="ui")
 ```
 
 ### Available Resources
@@ -544,7 +669,149 @@ You can override any configuration by setting environment variables:
 export JIRA_SERVER_URL="https://custom-jira.company.com"
 export JIRA_TIMEOUT="60"
 export JIRA_MAX_RESULTS="200"
+export JIRA_TEAMS='{"frontend": ["alice", "bob"], "backend": ["charlie"]}'
+export JIRA_COMPONENT_ALIASES='{"ui": "User Interface", "be": "Backend Services", "infra": "Infrastructure"}'
 ```
+
+### Team Configuration
+
+Teams can be configured in two ways:
+
+#### 1. Environment Variable (Static)
+
+Set the `JIRA_TEAMS` environment variable in your `.env` file:
+
+```env
+JIRA_TEAMS={"frontend": ["alice", "bob"], "backend": ["charlie", "david"]}
+```
+
+#### 2. Dynamic Configuration (Runtime)
+
+Use the MCP tools to manage teams dynamically:
+
+```python
+# Add a new team
+add_team(team_name="devops", members=["eve", "frank"])
+
+# Update an existing team
+add_team(team_name="frontend", members=["alice", "bob", "grace"])
+
+# Remove a team
+remove_team(team_name="legacy-team")
+
+# List all teams
+list_teams()
+```
+
+#### Using Teams
+
+Once teams are configured, you can:
+
+1. **Assign teams when creating issues**:
+```python
+create_issue(
+    project_key="PROJ",
+    summary="New feature",
+    description="Implement new login flow",
+    team="frontend"  # All frontend members become watchers
+)
+```
+
+2. **Assign teams to existing issues**:
+```python
+assign_team_to_issue(
+    issue_key="PROJ-123",
+    team_name="backend"
+)
+```
+
+3. **Check who's watching**:
+```python
+get_issue_watchers(issue_key="PROJ-123")
+```
+
+#### Team Benefits
+
+- **Visibility**: All team members are automatically notified of issue updates
+- **Collaboration**: Ensures the whole team stays informed
+- **Flexibility**: Teams can be configured per environment or project
+- **Scalability**: Easily manage large teams without adding watchers one by one
+
+### Component Alias Configuration
+
+Component aliases allow you to use short, memorable names instead of long component names when creating or updating Jira issues. This is especially useful when component names are lengthy or difficult to remember.
+
+#### 1. Environment Variable (Static)
+
+Set the `JIRA_COMPONENT_ALIASES` environment variable in your `.env` file:
+
+```env
+JIRA_COMPONENT_ALIASES={"ui": "User Interface", "be": "Backend Services", "infra": "Infrastructure", "db": "Database"}
+```
+
+#### 2. Dynamic Configuration (Runtime)
+
+Use the MCP tools to manage component aliases dynamically:
+
+```python
+# Add a new component alias
+add_component_alias(alias="ui", component_name="User Interface")
+
+# Update an existing alias
+add_component_alias(alias="ui", component_name="User Interface v2")
+
+# Remove an alias
+remove_component_alias(alias="legacy")
+
+# List all component aliases
+list_component_aliases()
+```
+
+#### Using Component Aliases
+
+Once configured, you can use aliases anywhere you would use component names:
+
+1. **Creating issues with component aliases**:
+```python
+create_issue(
+    project_key="PROJ",
+    summary="Fix UI bug",
+    description="Button is not clickable",
+    issue_type="Bug",
+    priority="High",
+    components=["ui", "be"]  # Will resolve to ["User Interface", "Backend Services"]
+)
+```
+
+2. **Updating issues with component aliases**:
+```python
+update_issue(
+    issue_key="PROJ-123",
+    components=["ui", "db"]  # Mix of aliases
+)
+```
+
+3. **Mixing aliases with actual component names**:
+```python
+create_issue(
+    project_key="PROJ",
+    summary="Database optimization",
+    description="Optimize queries",
+    issue_type="Task",
+    priority="Medium",
+    components=["db", "Performance Testing"]  # Alias + actual name
+)
+```
+
+#### Component Alias Benefits
+
+- **Convenience**: Use short aliases instead of typing long component names
+- **Consistency**: Standardize component naming across your team
+- **Flexibility**: Mix aliases with actual component names as needed
+- **Error Reduction**: Reduce typos when specifying component names
+- **Efficiency**: Speed up issue creation and updates
+
+**Note:** Component aliases are case-sensitive. If a component name isn't found in the alias mapping, it will be used as-is (assumed to be the actual component name).
 
 ### Multiple Jira Instances
 

--- a/doc/COMPONENT_ALIASES.md
+++ b/doc/COMPONENT_ALIASES.md
@@ -1,0 +1,323 @@
+# Component Aliases Feature
+
+This document provides a comprehensive guide to the Component Aliases feature in the Jira MCP Server.
+
+## Overview
+
+Component aliases allow you to use short, memorable names instead of long component names when creating or updating Jira issues. This feature is especially useful when:
+
+- Component names are lengthy (e.g., "Advanced Cluster Management - User Interface")
+- You work with the same components frequently
+- You want to reduce typing and potential typos
+- You want to standardize component naming across your team
+
+## Features
+
+- **Alias Resolution**: Automatically resolves aliases to actual component names
+- **Mixed Usage**: Use aliases and actual component names together
+- **Dynamic Configuration**: Add, update, and remove aliases at runtime
+- **Environment Configuration**: Pre-configure aliases via environment variables
+- **Case-Sensitive**: Aliases are case-sensitive for precise matching
+
+## Configuration
+
+### Static Configuration (Environment Variable)
+
+Add component aliases to your `.env` file:
+
+```env
+JIRA_COMPONENT_ALIASES={"ui": "User Interface", "be": "Backend Services", "infra": "Infrastructure", "db": "Database"}
+```
+
+### Dynamic Configuration (Runtime)
+
+Use MCP tools to manage aliases during runtime:
+
+```python
+# Add a new alias
+add_component_alias(alias="ui", component_name="User Interface")
+
+# Update an existing alias
+add_component_alias(alias="ui", component_name="User Interface v2")
+
+# Remove an alias
+remove_component_alias(alias="ui")
+
+# List all aliases
+list_component_aliases()
+```
+
+## Usage Examples
+
+### Creating Issues with Aliases
+
+```python
+# Use aliases in the components parameter
+create_issue(
+    project_key="ACM",
+    summary="Fix login button",
+    description="The login button is not responding to clicks",
+    issue_type="Bug",
+    priority="High",
+    work_type="46654",
+    due_date="2025-12-31",
+    components=["ui", "be"]  # Will resolve to ["User Interface", "Backend Services"]
+)
+```
+
+### Updating Issues with Aliases
+
+```python
+# Update components using aliases
+update_issue(
+    issue_key="ACM-123",
+    priority="High",
+    work_type="46654",
+    due_date="2025-12-31",
+    components=["ui", "db"]  # Mix of aliases
+)
+```
+
+### Mixing Aliases with Actual Names
+
+```python
+# You can mix aliases with actual component names
+create_issue(
+    project_key="ACM",
+    summary="Database optimization",
+    description="Optimize database queries for better performance",
+    issue_type="Task",
+    priority="Medium",
+    work_type="46654",
+    due_date="2025-12-31",
+    components=["db", "Performance Testing"]  # Alias + actual name
+)
+```
+
+## MCP Tools
+
+### `list_component_aliases`
+
+List all configured component aliases.
+
+**Returns**: A dictionary mapping aliases to actual component names
+
+**Example**:
+```python
+aliases = list_component_aliases()
+# Returns: {"ui": "User Interface", "be": "Backend Services", ...}
+```
+
+### `add_component_alias`
+
+Add or update a component alias.
+
+**Parameters**:
+- `alias` (str): Short alias for the component (e.g., "ui", "be")
+- `component_name` (str): Actual component name in Jira
+
+**Returns**: Updated dictionary of all component aliases
+
+**Example**:
+```python
+add_component_alias(alias="ui", component_name="User Interface")
+add_component_alias(alias="fe", component_name="Frontend")
+```
+
+### `remove_component_alias`
+
+Remove a component alias.
+
+**Parameters**:
+- `alias` (str): Alias to remove
+
+**Returns**: Updated dictionary of remaining component aliases
+
+**Raises**: `ValueError` if the alias doesn't exist
+
+**Example**:
+```python
+remove_component_alias(alias="ui")
+```
+
+## Implementation Details
+
+### How Alias Resolution Works
+
+1. When you create or update an issue with components, the server checks each component name
+2. If the component name matches an alias in the configuration, it's replaced with the actual component name
+3. If no alias is found, the component name is used as-is (assumed to be the actual name)
+4. The resolved component names are then sent to Jira
+
+### Code Flow
+
+```
+User Input: ["ui", "Database"]
+    ↓
+Alias Resolution: 
+    "ui" → "User Interface" (found in aliases)
+    "Database" → "Database" (not an alias, used as-is)
+    ↓
+Result: ["User Interface", "Database"]
+    ↓
+Sent to Jira API
+```
+
+### Configuration Storage
+
+Component aliases are stored in the `JiraConfig` class:
+
+```python
+class JiraConfig(BaseModel):
+    # ... other fields ...
+    component_aliases: Dict[str, str] = Field(
+        default_factory=dict, 
+        description="Component alias definitions mapping aliases to actual component names"
+    )
+```
+
+## Best Practices
+
+1. **Use Short, Memorable Aliases**: Keep aliases short (2-5 characters) for maximum efficiency
+   - Good: `ui`, `be`, `db`, `infra`
+   - Avoid: `user_interface_component`, `backend_services_v2`
+
+2. **Document Your Aliases**: Keep a team document of standard aliases
+   ```
+   ui    → User Interface
+   be    → Backend Services
+   db    → Database
+   infra → Infrastructure
+   fe    → Frontend
+   api   → API Gateway
+   ```
+
+3. **Consistency**: Use the same aliases across your team for better collaboration
+
+4. **Case Sensitivity**: Remember aliases are case-sensitive
+   - `ui` ≠ `UI` ≠ `Ui`
+
+5. **Fallback to Actual Names**: If you're unsure, use the actual component name - it will work fine
+
+6. **Environment vs Runtime**: 
+   - Use environment variables for stable, team-wide aliases
+   - Use runtime tools for experimental or temporary aliases
+
+## Testing
+
+The component alias feature includes comprehensive tests in `tests/test_component_aliases.py`:
+
+- Configuration from environment variables
+- Adding, updating, and removing aliases
+- Alias resolution (single and batch)
+- Mixed usage of aliases and actual names
+- Error handling for non-existent aliases
+- Coexistence with team management feature
+
+## Troubleshooting
+
+### Alias Not Resolving
+
+**Problem**: Component alias is not being resolved to actual name
+
+**Solutions**:
+1. Check if the alias is configured: `list_component_aliases()`
+2. Verify case sensitivity (aliases are case-sensitive)
+3. Ensure the alias was added successfully
+4. Check for typos in the alias name
+
+### Component Not Found in Jira
+
+**Problem**: Jira returns "component not found" error
+
+**Solutions**:
+1. Verify the actual component name exists in Jira
+2. Check the component name spelling (even after alias resolution)
+3. Use `get_project_components(project_key)` to see available components
+4. Ensure you have permissions to use the component
+
+### Alias Conflicts
+
+**Problem**: An alias matches an actual component name
+
+**Solution**: The alias will take precedence. Consider renaming the alias to avoid confusion.
+
+## API Reference
+
+### Configuration Methods
+
+```python
+# Get actual component name from alias (or return as-is)
+config.get_component_name(alias_or_name: str) -> str
+
+# Resolve a list of aliases/names
+config.resolve_component_names(aliases_or_names: List[str]) -> List[str]
+
+# Add or update an alias
+config.add_component_alias(alias: str, component_name: str) -> None
+
+# Remove an alias
+config.remove_component_alias(alias: str) -> None
+
+# List all aliases
+config.list_component_aliases() -> Dict[str, str]
+```
+
+## Examples from Real Use Cases
+
+### Red Hat Advanced Cluster Management
+
+```python
+# Configure common ACM component aliases
+add_component_alias("addon", "Hypershift Addon Operator")
+add_component_alias("hcp", "Hosted Control Planes")
+add_component_alias("infra", "Infrastructure Management")
+add_component_alias("ui", "Web Console")
+
+# Create issue using aliases
+create_issue(
+    project_key="ACM",
+    summary="Fix addon deployment issue",
+    description="Addon fails to deploy on new clusters",
+    issue_type="Bug",
+    priority="High",
+    work_type="46651",  # Incident & Support
+    due_date="2025-11-30",
+    components=["addon", "hcp"]  # Resolves to actual component names
+)
+```
+
+### Multi-Component Projects
+
+```python
+# Configure aliases for different areas
+add_component_alias("fe", "Frontend React Application")
+add_component_alias("be", "Backend Node.js Services")
+add_component_alias("db", "PostgreSQL Database")
+add_component_alias("auth", "Authentication Service")
+add_component_alias("api", "REST API Gateway")
+
+# Create issue affecting multiple components
+create_issue(
+    project_key="MYAPP",
+    summary="Performance degradation across stack",
+    description="Response times increased by 50% in production",
+    issue_type="Bug",
+    priority="Critical",
+    work_type="46651",
+    due_date="2025-11-20",
+    components=["fe", "api", "db"]  # Three components with short aliases
+)
+```
+
+## Conclusion
+
+Component aliases significantly improve the efficiency of working with Jira through the MCP server. By using short, memorable aliases, you can:
+
+- Create and update issues faster
+- Reduce typing errors
+- Maintain consistency across your team
+- Focus on the task rather than remembering exact component names
+
+For more information, see the main README.md file or check the implementation in `jira_mcp_server/config.py` and `jira_mcp_server/server.py`.
+

--- a/doc/SEARCH_BY_TEAM_FEATURE.md
+++ b/doc/SEARCH_BY_TEAM_FEATURE.md
@@ -1,0 +1,298 @@
+# Search Issues by Team Feature
+
+## Overview
+
+Added a new `search_issues_by_team` tool that allows you to find all Jira issues assigned to any member of a configured team. This enhancement makes it easy to track team workload and see what issues a team is working on.
+
+## Date
+2025-11-14
+
+## Feature Description
+
+The new tool automatically generates JQL queries to search for issues where the assignee is one of the team members. This is different from the watcher functionality - it specifically finds issues **assigned to** team members, not just watched by them.
+
+## Key Difference
+
+**Watchers vs Assignees:**
+- **Watchers**: Team members who receive notifications about issue updates
+- **Assignees**: Team members who are responsible for working on issues
+
+The `search_issues_by_team` tool searches for **assignees**, making it perfect for:
+- Tracking team workload
+- Sprint planning
+- Capacity management
+- Finding who's working on what
+
+## Changes Made
+
+### 1. New MCP Tool: `search_issues_by_team`
+
+**File**: `jira_mcp_server/server.py`
+
+**Location**: Added after `search_issues` tool (lines 198-256)
+
+**Parameters**:
+- `team_name` (required): Name of the team to search for
+- `project_key` (optional): Filter by specific project
+- `status` (optional): Filter by issue status
+- `max_results` (optional): Maximum results to return (default: 100)
+
+**Returns**: List of `IssueResponse` objects
+
+### 2. Documentation Updates
+
+**Files Updated**:
+- `README.md`: Added tool description and examples
+- `TEAM_MANAGEMENT.md`: Added comprehensive "Searching for Team Issues" section
+- `TEAM_QUICKSTART.md`: Added quick examples and AI assistant usage
+
+## Usage Examples
+
+### Basic Usage
+
+```python
+# Find all issues assigned to frontend team
+search_issues_by_team(team_name="frontend")
+```
+
+### With Filters
+
+```python
+# Find open issues assigned to backend team
+search_issues_by_team(
+    team_name="backend",
+    status="Open"
+)
+
+# Find frontend team issues in specific project
+search_issues_by_team(
+    team_name="frontend",
+    project_key="PROJ",
+    status="In Progress"
+)
+```
+
+### With AI Assistants
+
+Simply ask natural language questions:
+- "Find all issues assigned to the frontend team"
+- "Show me open issues for the backend team"
+- "What issues is the devops team working on?"
+- "List all In Progress issues assigned to the QA team"
+
+## How It Works
+
+The tool automatically generates JQL queries based on team configuration:
+
+**Example:**
+
+For a team configured as:
+```json
+{"frontend": ["alice", "bob", "charlie"]}
+```
+
+The call:
+```python
+search_issues_by_team(
+    team_name="frontend",
+    project_key="PROJ",
+    status="Open"
+)
+```
+
+Generates the JQL:
+```jql
+project = PROJ AND (assignee = "alice" OR assignee = "bob" OR assignee = "charlie") AND status = "Open"
+```
+
+## Use Cases
+
+### 1. Sprint Planning
+```python
+# Check team's current workload before planning
+in_progress = search_issues_by_team(
+    team_name="development",
+    status="In Progress"
+)
+print(f"Team has {len(in_progress)} issues in progress")
+```
+
+### 2. Capacity Management
+```python
+# Analyze team workload across different statuses
+in_progress = search_issues_by_team(team_name="frontend", status="In Progress")
+open_issues = search_issues_by_team(team_name="frontend", status="Open")
+
+print(f"Frontend team:")
+print(f"  - Working on: {len(in_progress)} issues")
+print(f"  - Backlog: {len(open_issues)} issues")
+```
+
+### 3. Feature Team Tracking
+```python
+# Track progress of a feature team
+feature_team_issues = search_issues_by_team(team_name="payment-feature")
+print(f"Payment feature team has {len(feature_team_issues)} total issues")
+```
+
+### 4. Cross-Project Visibility
+```python
+# See what a team is working on across multiple projects
+all_team_work = search_issues_by_team(team_name="platform")
+# Returns issues from all projects
+```
+
+## Implementation Details
+
+### JQL Generation Logic
+
+1. **Get team members** from configuration
+2. **Build assignee clause**: `(assignee = "user1" OR assignee = "user2" OR ...)`
+3. **Add optional filters**:
+   - Project: `project = PROJ`
+   - Status: `status = "Open"`
+4. **Combine with AND**: `project = PROJ AND (assignee clause) AND status = "Open"`
+5. **Execute search** using existing `search_issues` method
+
+### Error Handling
+
+- **Team not found**: Clear error message with available teams
+- **Empty team**: ValueError if team has no members
+- **Search failures**: Propagated with context information
+
+## Testing
+
+All tests passed successfully:
+
+```
+✓ Test 1: Importing modules
+✓ Test 2: Creating config with teams
+✓ Test 3: Verifying team members
+✓ Test 4: Testing JQL generation logic
+  Generated JQL: project = PROJ AND (assignee = "alice" OR assignee = "bob") AND status = "Open"
+✓ Test 5: Testing JQL without filters
+  Generated JQL: (assignee = "alice" OR assignee = "bob")
+✓ Test 6: Verifying search_issues_by_team tool exists
+  Server initialized successfully
+```
+
+## API Reference
+
+### `search_issues_by_team`
+
+Search for issues assigned to any member of a team.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `team_name` | str | Yes | Name of the team to search for |
+| `project_key` | str | No | Project key to filter results (e.g., 'PROJ') |
+| `status` | str | No | Status to filter results (e.g., 'Open', 'In Progress') |
+| `max_results` | int | No | Maximum number of results (default: 100) |
+
+**Returns:** `List[IssueResponse]`
+
+**Raises:**
+- `ValueError`: If team doesn't exist or has no members
+- `Exception`: For search failures
+
+## Benefits
+
+1. **Simplified Queries**: No need to manually construct complex JQL with OR clauses
+2. **Team-Centric**: Naturally organize work by team rather than individual
+3. **Flexible Filtering**: Optional project and status filters for refined searches
+4. **AI-Friendly**: Works seamlessly with natural language questions
+5. **Workload Visibility**: Easy to see what each team is working on
+
+## Comparison: Watchers vs Assignees
+
+| Feature | Watchers | Assignees (this tool) |
+|---------|----------|----------------------|
+| **Purpose** | Get notifications | Responsible for work |
+| **Tool** | `assign_team_to_issue` | `search_issues_by_team` |
+| **Search By** | N/A (no search tool) | This new tool |
+| **Use Case** | Keep team informed | Find team's work |
+| **Action** | Add/remove watchers | Search assigned issues |
+
+## Future Enhancements
+
+Potential improvements:
+
+1. **Additional Filters**: Priority, labels, components
+2. **Date Ranges**: Created date, updated date filters
+3. **Aggregation**: Group by status, priority, etc.
+4. **Export**: Export results to CSV or JSON
+5. **Trend Analysis**: Track team velocity over time
+
+## Backward Compatibility
+
+✅ **Fully backward compatible** - this is a new tool that doesn't affect existing functionality.
+
+## Examples for Different Scenarios
+
+### Daily Standup Preparation
+```python
+# See what the team worked on
+team_issues = search_issues_by_team(
+    team_name="backend",
+    status="In Progress"
+)
+for issue in team_issues:
+    print(f"{issue.key}: {issue.summary} (Assignee: {issue.assignee})")
+```
+
+### Sprint Review
+```python
+# Find completed work
+completed = search_issues_by_team(
+    team_name="frontend",
+    status="Done"
+)
+print(f"Team completed {len(completed)} issues this sprint")
+```
+
+### Resource Planning
+```python
+# Check workload across teams
+for team in ["frontend", "backend", "devops"]:
+    issues = search_issues_by_team(team_name=team)
+    print(f"{team}: {len(issues)} total issues")
+```
+
+## Documentation
+
+All documentation has been updated with:
+- Tool description and parameters
+- Usage examples
+- AI assistant integration examples
+- Use case scenarios
+- Quick reference guide
+
+## Related Files
+
+- `jira_mcp_server/server.py`: Implementation
+- `README.md`: Main documentation
+- `TEAM_MANAGEMENT.md`: Comprehensive team management guide
+- `TEAM_QUICKSTART.md`: Quick start guide
+- This document: Feature specification
+
+## Authors
+
+- AI Assistant (Claude Sonnet 4.5)
+- User: rjung@redhat.com
+
+## Status
+
+✅ **Complete and Ready**
+- Implementation: ✅ Done
+- Testing: ✅ Passed
+- Documentation: ✅ Updated
+- Examples: ✅ Provided
+
+---
+
+**Version**: 1.0.0  
+**Last Updated**: 2025-11-14  
+**Feature Type**: Enhancement
+

--- a/doc/TEAM_MANAGEMENT.md
+++ b/doc/TEAM_MANAGEMENT.md
@@ -1,0 +1,473 @@
+# Team Management Feature
+
+## Overview
+
+The Jira MCP Server now supports comprehensive team management, allowing you to define teams with multiple members and automatically assign them to issues as watchers. This feature enables better collaboration and ensures all team members stay informed about relevant issues.
+
+## Key Features
+
+### 1. **Team Configuration**
+- Define teams with multiple members
+- Configure teams via environment variables or dynamically at runtime
+- Support for unlimited teams and team members
+
+### 2. **Automatic Watcher Assignment**
+- When a team is assigned to an issue, all team members are automatically added as watchers
+- Team members receive notifications for all issue updates
+- Ensures complete visibility across the team
+
+### 3. **Flexible Team Management**
+- Add, update, and remove teams at runtime
+- List all configured teams and their members
+- No need to restart the server when teams change
+
+### 4. **Individual Watcher Control**
+- Add or remove individual watchers
+- Query all watchers on an issue
+- Fine-grained control over notifications
+
+## Configuration
+
+### Important: Username vs Email
+
+**⚠️ Use Usernames, Not Email Addresses**
+
+The Jira API requires **usernames** (or account IDs for Jira Cloud), not email addresses:
+
+- **Jira Server/Data Center**: Use the username (e.g., `"alice"`, not `"alice@example.com"`)
+- **Jira Cloud**: Use the account ID or username (e.g., `"alice"` or `"5d123456789"`)
+
+Email addresses will **not work** and will cause watcher additions to fail.
+
+To find usernames:
+1. Check the user's profile in Jira
+2. Use the Jira API: `GET /rest/api/2/user/search?query=email@example.com`
+3. Ask your Jira administrator
+
+### Method 1: Environment Variable (Static)
+
+Configure teams in your `.env` file:
+
+```env
+JIRA_TEAMS={"frontend": ["alice", "bob"], "backend": ["charlie", "david"], "devops": ["eve"]}
+```
+
+This is ideal for:
+- Stable team structures
+- Production environments
+- Team configurations that rarely change
+
+### Method 2: Dynamic Configuration (Runtime)
+
+Use MCP tools to manage teams on the fly:
+
+```python
+# Add a new team
+add_team(team_name="frontend", members=["alice", "bob", "charlie"])
+
+# Update an existing team
+add_team(team_name="frontend", members=["alice", "bob", "grace"])
+
+# Remove a team
+remove_team(team_name="old-team")
+
+# List all teams
+list_teams()
+```
+
+This is ideal for:
+- Dynamic team structures
+- Testing and development
+- Temporary teams or project-based teams
+
+## Usage Examples
+
+### Creating Issues with Team Assignment
+
+When creating a new issue, specify the `team` parameter to automatically add all team members as watchers:
+
+```python
+create_issue(
+    project_key="PROJ",
+    summary="Implement new login flow",
+    description="Redesign the authentication system",
+    issue_type="Story",
+    priority="High",
+    team="frontend"  # All frontend team members become watchers
+)
+```
+
+### Assigning Teams to Existing Issues
+
+Use the `assign_team_to_issue` tool to add a team to an existing issue:
+
+```python
+assign_team_to_issue(
+    issue_key="PROJ-123",
+    team_name="backend"
+)
+```
+
+This returns:
+```json
+{
+  "issue_key": "PROJ-123",
+  "team_name": "backend",
+  "successes": ["charlie", "david"],
+  "failures": [],
+  "total_added": 2,
+  "total_failed": 0
+}
+```
+
+### Managing Individual Watchers
+
+#### Add a watcher
+```python
+add_watcher_to_issue(issue_key="PROJ-123", username="frank")
+```
+
+#### Remove a watcher
+```python
+remove_watcher_from_issue(issue_key="PROJ-123", username="frank")
+```
+
+#### List all watchers
+```python
+get_issue_watchers(issue_key="PROJ-123")
+```
+
+Returns:
+```json
+[
+  {
+    "username": "alice",
+    "display_name": "Alice Smith",
+    "email": "alice@example.com",
+    "active": true
+  },
+  {
+    "username": "bob",
+    "display_name": "Bob Johnson",
+    "email": "bob@example.com",
+    "active": true
+  }
+]
+```
+
+## Available Tools
+
+### Team Management
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `list_teams` | List all configured teams | None |
+| `add_team` | Add or update a team | `team_name`, `members` |
+| `remove_team` | Remove a team | `team_name` |
+| `assign_team_to_issue` | Assign team to an issue | `issue_key`, `team_name` |
+| `search_issues_by_team` | Find issues assigned to team members | `team_name`, `project_key` (opt), `status` (opt) |
+
+### Watcher Management
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `get_issue_watchers` | Get all watchers on an issue | `issue_key` |
+| `add_watcher_to_issue` | Add a single watcher | `issue_key`, `username` |
+| `remove_watcher_from_issue` | Remove a watcher | `issue_key`, `username` |
+
+## Searching for Team Issues
+
+### Finding Issues Assigned to a Team
+
+Use the `search_issues_by_team` tool to find all issues assigned to any team member:
+
+```python
+# Find all issues assigned to frontend team
+search_issues_by_team(team_name="frontend")
+
+# Find open issues assigned to backend team
+search_issues_by_team(
+    team_name="backend",
+    status="Open"
+)
+
+# Find frontend team issues in a specific project
+search_issues_by_team(
+    team_name="frontend",
+    project_key="PROJ",
+    status="In Progress"
+)
+```
+
+### How It Works
+
+The tool automatically generates the appropriate JQL query:
+
+**Example:** For a team with members `["alice", "bob", "charlie"]`:
+
+```python
+search_issues_by_team(team_name="frontend", project_key="PROJ", status="Open")
+```
+
+Generates:
+```jql
+project = PROJ AND (assignee = "alice" OR assignee = "bob" OR assignee = "charlie") AND status = "Open"
+```
+
+### Use with AI Assistants
+
+Simply ask natural language questions:
+- "Find all issues assigned to the frontend team"
+- "Show me open issues for the backend team"
+- "What issues is the devops team working on?"
+- "List all In Progress issues assigned to the QA team"
+
+## Use Cases
+
+### 1. Sprint Planning
+```python
+# Create a sprint issue and assign it to the development team
+create_issue(
+    project_key="PROJ",
+    summary="Sprint 23 Planning",
+    description="Plan work for sprint 23",
+    issue_type="Task",
+    team="development",
+    labels=["sprint-23", "planning"]
+)
+
+# Review what the team is currently working on
+issues = search_issues_by_team(
+    team_name="development",
+    status="In Progress"
+)
+print(f"Team has {len(issues)} issues in progress")
+```
+
+### 2. Incident Management
+```python
+# Create a critical incident and notify the on-call team
+create_issue(
+    project_key="PROJ",
+    summary="Production outage - Login service down",
+    description="Users unable to login",
+    issue_type="Bug",
+    priority="Critical",
+    team="oncall"
+)
+```
+
+### 3. Cross-Team Collaboration
+```python
+# Assign multiple teams to a large initiative
+assign_team_to_issue(issue_key="PROJ-100", team_name="frontend")
+assign_team_to_issue(issue_key="PROJ-100", team_name="backend")
+assign_team_to_issue(issue_key="PROJ-100", team_name="devops")
+```
+
+### 4. Feature Development
+```python
+# Configure a feature team dynamically
+add_team(
+    team_name="payment-feature",
+    members=["alice", "bob", "charlie", "eve"]
+)
+
+# Assign all payment-related issues to the feature team
+assign_team_to_issue(issue_key="PROJ-201", team_name="payment-feature")
+assign_team_to_issue(issue_key="PROJ-202", team_name="payment-feature")
+
+# Check team's workload
+workload = search_issues_by_team(team_name="payment-feature")
+print(f"Payment feature team has {len(workload)} total issues")
+```
+
+### 5. Team Capacity Planning
+```python
+# Check team workload across different statuses
+in_progress = search_issues_by_team(
+    team_name="frontend",
+    status="In Progress"
+)
+
+open_issues = search_issues_by_team(
+    team_name="frontend",
+    status="Open"
+)
+
+print(f"Frontend team:")
+print(f"  - Working on: {len(in_progress)} issues")
+print(f"  - Backlog: {len(open_issues)} issues")
+```
+
+## Benefits
+
+### 1. **Improved Visibility**
+All team members are automatically notified of updates, ensuring everyone stays informed.
+
+### 2. **Simplified Collaboration**
+No need to add watchers one by one—assign the entire team with a single command.
+
+### 3. **Flexible Configuration**
+Teams can be configured statically in environment variables or dynamically at runtime.
+
+### 4. **Scalability**
+Easily manage large teams across multiple projects without manual watcher management.
+
+### 5. **Environment-Specific Teams**
+Different team configurations for production, staging, and development environments.
+
+## Implementation Details
+
+### Backend Components
+
+1. **config.py**: Extended with team configuration support
+   - `teams` field in `JiraConfig`
+   - Methods: `get_team_members()`, `add_team()`, `remove_team()`, `list_teams()`
+
+2. **client.py**: Added watcher management methods
+   - `add_watcher()`: Add a single watcher
+   - `remove_watcher()`: Remove a watcher
+   - `get_watchers()`: List all watchers
+   - `add_team_as_watchers()`: Bulk add team members
+
+3. **server.py**: New MCP tools
+   - Team management tools: `list_teams`, `add_team`, `remove_team`, `assign_team_to_issue`
+   - Watcher management tools: `get_issue_watchers`, `add_watcher_to_issue`, `remove_watcher_from_issue`
+   - Extended `create_issue` with `team` parameter
+
+### Data Models
+
+```python
+class WatcherResponse(BaseModel):
+    username: str
+    display_name: str
+    email: Optional[str]
+    active: bool
+
+class TeamAssignmentResponse(BaseModel):
+    issue_key: str
+    team_name: str
+    successes: List[str]
+    failures: List[Dict[str, str]]
+    total_added: int
+    total_failed: int
+
+class TeamInfoResponse(BaseModel):
+    teams: Dict[str, List[str]]
+```
+
+## Error Handling
+
+The team management feature includes robust error handling:
+
+1. **Missing Team**: Clear error message when referencing a non-existent team
+2. **Partial Failures**: When adding team watchers, successes and failures are tracked separately
+3. **Permission Errors**: Graceful handling when users don't have permission to add watchers
+4. **Invalid Usernames**: Failed additions are reported without blocking successful ones
+
+## Best Practices
+
+### 1. **Team Naming**
+- Use clear, descriptive names: `frontend`, `backend`, `devops`
+- Avoid generic names: `team1`, `group-a`
+- Consider including project context: `proj-frontend`, `proj-backend`
+
+### 2. **Team Size**
+- Keep teams focused (5-10 members ideal)
+- Create specialized teams for different areas
+- Use multiple teams for cross-functional work
+
+### 3. **Configuration Management**
+- Use environment variables for stable teams
+- Use dynamic configuration for temporary teams
+- Document team membership in your project
+
+### 4. **Combining with Other Features**
+- Use teams with labels for categorization
+- Combine team assignment with specific assignees
+- Use teams for notification, assignee for responsibility
+
+### 5. **Security Considerations**
+- Ensure team members have access to the project
+- Use security levels to restrict comment visibility
+- Review team membership regularly
+
+## Troubleshooting
+
+### Team Not Found
+**Error**: `Team 'frontend' not found`
+
+**Solution**: 
+1. Check team configuration in `.env`
+2. Use `list_teams()` to see available teams
+3. Add the team with `add_team()`
+
+### Permission Denied When Adding Watchers
+**Error**: `Failed to add watcher alice to PROJ-123`
+
+**Solution**:
+1. Verify the user exists in Jira
+2. **Use username, not email address!** (common issue)
+3. Check if user has access to the project
+4. Ensure you have permission to add watchers
+5. For Jira Cloud, you may need to use account IDs instead of usernames
+
+### Partial Team Assignment
+**Issue**: Some team members added, others failed
+
+**Explanation**: This is normal when:
+- Some users don't have project access
+- Some usernames are invalid
+- Check the `failures` array in the response
+
+## Future Enhancements
+
+Potential future improvements to the team management feature:
+
+1. **Team Hierarchies**: Support for nested teams (e.g., `engineering.frontend`)
+2. **Team Roles**: Different roles within teams (lead, member, reviewer)
+3. **Persistent Storage**: Save team configurations to database
+4. **Team Analytics**: Track team activity and engagement
+5. **Integration with Jira Groups**: Sync with native Jira groups
+6. **Notification Preferences**: Per-team notification settings
+
+## Migration Guide
+
+If you're already using the Jira MCP Server, here's how to adopt team management:
+
+### Step 1: Update Configuration
+Add teams to your `.env` file:
+```env
+JIRA_TEAMS={"your-team": ["member1", "member2"]}
+```
+
+### Step 2: Test Team Assignment
+Try assigning a team to an existing issue:
+```python
+assign_team_to_issue(issue_key="EXISTING-123", team_name="your-team")
+```
+
+### Step 3: Update Workflows
+Modify your issue creation workflows to include team assignment:
+```python
+create_issue(..., team="your-team")
+```
+
+### Step 4: Train Your Team
+Share this documentation with your team and demonstrate the new features.
+
+## Support
+
+For issues or questions about team management:
+1. Check this documentation
+2. Review the [README](README.md)
+3. Open an issue on GitHub
+4. Check Jira API documentation for watcher permissions
+
+---
+
+**Version**: 1.0.0  
+**Last Updated**: 2025-11-14  
+**Minimum Server Version**: 1.0.0
+

--- a/doc/TEAM_QUICKSTART.md
+++ b/doc/TEAM_QUICKSTART.md
@@ -1,0 +1,243 @@
+# Team Management Quick Start Guide
+
+## 🚀 Get Started in 5 Minutes
+
+This guide will help you quickly set up and use team management in the Jira MCP Server.
+
+## Step 1: Configure Your Teams (30 seconds)
+
+Add teams to your `.env` file:
+
+```env
+JIRA_TEAMS={"frontend": ["alice", "bob"], "backend": ["charlie", "david"]}
+```
+
+**Format:** JSON with team names as keys and member arrays as values.
+
+**⚠️ Important:** Use **usernames**, not email addresses! Email addresses will not work.
+- ✅ Good: `"alice"`, `"bob"`
+- ❌ Bad: `"alice@example.com"`, `"bob@example.com"`
+
+## Step 2: Create an Issue with Team Assignment (1 minute)
+
+When creating a new issue, add the `team` parameter:
+
+```python
+create_issue(
+    project_key="PROJ",
+    summary="Fix login bug",
+    description="Users can't log in",
+    issue_type="Bug",
+    priority="High",
+    team="frontend"  # 👈 All frontend members become watchers
+)
+```
+
+✅ **Result:** Issue created, and alice + bob are automatically added as watchers!
+
+## Step 3: Assign Team to Existing Issue (30 seconds)
+
+For existing issues, use `assign_team_to_issue`:
+
+```python
+assign_team_to_issue(
+    issue_key="PROJ-123",
+    team_name="backend"
+)
+```
+
+✅ **Result:** charlie + david are now watching PROJ-123!
+
+## Common Commands
+
+### View All Configured Teams
+```python
+list_teams()
+```
+
+### Add a New Team (Runtime)
+```python
+add_team(
+    team_name="devops",
+    members=["eve", "frank"]
+)
+```
+
+### See Who's Watching an Issue
+```python
+get_issue_watchers(issue_key="PROJ-123")
+```
+
+### Add Individual Watcher
+```python
+add_watcher_to_issue(issue_key="PROJ-123", username="grace")
+```
+
+### Remove Individual Watcher
+```python
+remove_watcher_from_issue(issue_key="PROJ-123", username="grace")
+```
+
+### Find Issues Assigned to a Team
+```python
+search_issues_by_team(team_name="frontend")
+
+# With filters
+search_issues_by_team(
+    team_name="backend",
+    project_key="PROJ",
+    status="In Progress"
+)
+```
+
+## Example: AI Assistant Usage
+
+With Claude Code, Cursor, or Gemini CLI, you can simply ask:
+
+```
+"Create a new bug for the login issue and assign it to the frontend team"
+
+"Show me who is watching PROJ-123"
+
+"Assign the backend team to PROJ-456"
+
+"Add alice as a watcher to PROJ-789"
+
+"Find all issues assigned to the frontend team"
+
+"Show me open issues for the backend team"
+```
+
+## Real-World Scenarios
+
+### Scenario 1: Sprint Planning
+```python
+# Create sprint task, notify entire dev team
+create_issue(
+    project_key="PROJ",
+    summary="Sprint 24 Planning",
+    description="Plan work for next sprint",
+    team="development"
+)
+```
+
+### Scenario 2: Critical Incident
+```python
+# Urgent bug, notify on-call team immediately
+create_issue(
+    project_key="PROD",
+    summary="Service Down - Payment Processing",
+    description="All payment transactions failing",
+    issue_type="Bug",
+    priority="Critical",
+    team="oncall"
+)
+```
+
+### Scenario 3: Cross-Team Feature
+```python
+# Create feature issue
+issue = create_issue(
+    project_key="PROJ",
+    summary="New Payment Gateway Integration",
+    description="Integrate Stripe payment gateway",
+    team="backend"
+)
+
+# Add frontend team too
+assign_team_to_issue(
+    issue_key=issue.key,
+    team_name="frontend"
+)
+```
+
+## Configuration Options
+
+### Option 1: Static (via Environment)
+Best for: Stable teams, production
+
+```env
+JIRA_TEAMS={"team1": ["user1", "user2"], "team2": ["user3"]}
+```
+
+### Option 2: Dynamic (via API)
+Best for: Temporary teams, testing
+
+```python
+add_team(team_name="feature-team", members=["alice", "bob", "eve"])
+# Use the team
+create_issue(..., team="feature-team")
+# Remove when done
+remove_team(team_name="feature-team")
+```
+
+## Tips & Best Practices
+
+### ✅ Do's
+- Use descriptive team names (`frontend`, `backend`, not `team1`)
+- Keep teams focused (5-10 members ideal)
+- Review team membership regularly
+- Use teams for visibility, assignee for responsibility
+
+### ❌ Don'ts
+- Don't create teams with too many members (>20)
+- Don't use generic names like `group1` or `team-a`
+- Don't forget to remove obsolete teams
+
+## Troubleshooting
+
+### Team not found?
+```bash
+# Check available teams
+list_teams()
+
+# Add the team if missing
+add_team(team_name="myteam", members=["user1", "user2"])
+```
+
+### Some team members not added?
+This is normal if:
+- User doesn't exist in Jira
+- User doesn't have access to the project
+- Username is incorrect
+- **You used email instead of username** ← Common mistake!
+
+Check the response for `failures` array to see which users failed.
+
+**Fix:** Use usernames instead of email addresses in your team configuration.
+
+### Permission denied?
+Ensure:
+1. You have permission to add watchers
+2. Team members have access to the project
+3. Usernames are correct
+
+## Next Steps
+
+1. **Read Full Documentation**: See [TEAM_MANAGEMENT.md](TEAM_MANAGEMENT.md)
+2. **Try Examples**: Run `python3 examples/team_management_example.py`
+3. **Configure Your Teams**: Update your `.env` file
+4. **Start Using**: Create issues with team assignment
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| List teams | `list_teams()` |
+| Add team | `add_team(name, members)` |
+| Remove team | `remove_team(name)` |
+| Create with team | `create_issue(..., team="name")` |
+| Assign team | `assign_team_to_issue(key, team)` |
+| Get watchers | `get_issue_watchers(key)` |
+| Add watcher | `add_watcher_to_issue(key, user)` |
+| Remove watcher | `remove_watcher_from_issue(key, user)` |
+| Find team issues | `search_issues_by_team(team, ...)` |
+
+---
+
+**Need Help?** Check [TEAM_MANAGEMENT.md](TEAM_MANAGEMENT.md) or [README.md](README.md)
+
+**Found a Bug?** Open an issue on GitHub
+
+**Have Feedback?** We'd love to hear from you!
+

--- a/examples/component_alias_example.py
+++ b/examples/component_alias_example.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Component Alias Management Example
+
+This example demonstrates how to use component aliases in the Jira MCP Server.
+"""
+
+import sys
+import os
+
+# Add parent directory to path to import jira_mcp_server
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from jira_mcp_server.config import JiraConfig
+
+
+def main():
+    """Demonstrate component alias functionality."""
+    
+    print("=" * 60)
+    print("Component Alias Management Example")
+    print("=" * 60)
+    print()
+    
+    # Create a config instance
+    config = JiraConfig(
+        server_url="https://example.atlassian.net",
+        access_token="dummy-token",
+        component_aliases={}
+    )
+    
+    # 1. Add component aliases
+    print("1. Adding component aliases...")
+    config.add_component_alias("ui", "User Interface")
+    config.add_component_alias("be", "Backend Services")
+    config.add_component_alias("db", "Database")
+    config.add_component_alias("infra", "Infrastructure")
+    print("   Added 4 aliases")
+    print()
+    
+    # 2. List all aliases
+    print("2. Listing all component aliases:")
+    aliases = config.list_component_aliases()
+    for alias, component_name in aliases.items():
+        print(f"   {alias:10s} → {component_name}")
+    print()
+    
+    # 3. Resolve individual aliases
+    print("3. Resolving individual aliases:")
+    test_inputs = ["ui", "be", "Unknown Component", "db"]
+    for input_name in test_inputs:
+        resolved = config.get_component_name(input_name)
+        if input_name in aliases:
+            print(f"   '{input_name}' → '{resolved}' (alias resolved)")
+        else:
+            print(f"   '{input_name}' → '{resolved}' (not an alias, used as-is)")
+    print()
+    
+    # 4. Resolve a list of component names (mix of aliases and actual names)
+    print("4. Resolving a list of component names:")
+    component_list = ["ui", "be", "Performance Testing", "db"]
+    print(f"   Input:    {component_list}")
+    resolved_list = config.resolve_component_names(component_list)
+    print(f"   Resolved: {resolved_list}")
+    print()
+    
+    # 5. Update an existing alias
+    print("5. Updating an existing alias:")
+    print(f"   Before: ui → {config.get_component_name('ui')}")
+    config.add_component_alias("ui", "User Interface v2")
+    print(f"   After:  ui → {config.get_component_name('ui')}")
+    print()
+    
+    # 6. Remove an alias
+    print("6. Removing an alias:")
+    print(f"   Current aliases: {list(config.list_component_aliases().keys())}")
+    config.remove_component_alias("infra")
+    print(f"   After removing 'infra': {list(config.list_component_aliases().keys())}")
+    print()
+    
+    # 7. Demonstrate use case: Creating an issue with components
+    print("7. Example: Components for creating a Jira issue")
+    components_to_use = ["ui", "be", "Integration Testing"]
+    print(f"   Components specified: {components_to_use}")
+    resolved_components = config.resolve_component_names(components_to_use)
+    print(f"   Components sent to Jira: {resolved_components}")
+    print()
+    
+    # 8. Load from environment variable (simulation)
+    print("8. Loading aliases from environment variable:")
+    os.environ["JIRA_COMPONENT_ALIASES"] = '{"fe": "Frontend", "api": "API Gateway"}'
+    config2 = JiraConfig.from_env()
+    print(f"   Loaded aliases: {config2.list_component_aliases()}")
+    print()
+    
+    print("=" * 60)
+    print("Component Alias Example Complete!")
+    print("=" * 60)
+    print()
+    print("Key Takeaways:")
+    print("  - Aliases make component names shorter and easier to use")
+    print("  - Mix aliases with actual component names freely")
+    print("  - Manage aliases dynamically at runtime or via environment")
+    print("  - Aliases are case-sensitive")
+    print("  - Unknown aliases are used as-is (assumed to be actual names)")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/team_management_example.py
+++ b/examples/team_management_example.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Example demonstrating team management features in Jira MCP Server.
+
+This example shows how to:
+1. Configure teams via environment variable
+2. Add/update teams dynamically
+3. Create issues with team assignment
+4. Assign teams to existing issues
+5. Manage individual watchers
+6. List watchers on issues
+"""
+
+import asyncio
+import os
+import json
+from jira_mcp_server.config import JiraConfig
+from jira_mcp_server.client import JiraClient
+
+
+async def main():
+    print("=" * 60)
+    print("Jira MCP Server - Team Management Example")
+    print("=" * 60)
+    print()
+    
+    # Example 1: Configure teams via environment variable
+    print("1. Configuring teams via environment variable")
+    print("-" * 60)
+    
+    # Set up teams in environment (normally done in .env file)
+    teams = {
+        "frontend": ["alice", "bob"],
+        "backend": ["charlie", "david"],
+        "devops": ["eve"]
+    }
+    os.environ["JIRA_TEAMS"] = json.dumps(teams)
+    
+    # Load configuration
+    config = JiraConfig.from_env()
+    print(f"Loaded teams: {list(config.teams.keys())}")
+    print()
+    
+    # Example 2: Dynamic team management
+    print("2. Dynamic team management")
+    print("-" * 60)
+    
+    # Add a new team
+    config.add_team("qa", ["frank", "grace"])
+    print(f"Added 'qa' team: {config.get_team_members('qa')}")
+    
+    # Update an existing team
+    config.add_team("frontend", ["alice", "bob", "henry"])
+    print(f"Updated 'frontend' team: {config.get_team_members('frontend')}")
+    
+    # List all teams
+    all_teams = config.list_teams()
+    print(f"\nAll teams:")
+    for team_name, members in all_teams.items():
+        print(f"  - {team_name}: {', '.join(members)}")
+    print()
+    
+    # Example 3: Using teams with Jira client (requires valid credentials)
+    print("3. Using teams with Jira (requires valid credentials)")
+    print("-" * 60)
+    
+    if config.server_url and config.access_token:
+        try:
+            # Initialize client
+            client = JiraClient(config)
+            await client.connect()
+            print("✓ Connected to Jira")
+            
+            # Example: Create an issue with team assignment
+            # Note: Uncomment and modify these examples for your Jira instance
+            
+            # issue = await client.create_issue(
+            #     project_key="PROJ",
+            #     summary="Example issue with team",
+            #     description="This issue will have the frontend team as watchers",
+            #     issue_type="Task",
+            #     priority={"name": "Medium"}
+            # )
+            # print(f"✓ Created issue: {issue['key']}")
+            #
+            # # Add team as watchers
+            # result = await client.add_team_as_watchers(
+            #     issue['key'],
+            #     config.get_team_members('frontend')
+            # )
+            # print(f"✓ Added {result['total_added']} watchers from 'frontend' team")
+            #
+            # # Get watchers
+            # watchers = await client.get_watchers(issue['key'])
+            # print(f"✓ Current watchers:")
+            # for watcher in watchers:
+            #     print(f"  - {watcher['display_name']} ({watcher['username']})")
+            
+            print("\n(Examples are commented out - uncomment to use with your Jira)")
+            
+        except Exception as e:
+            print(f"✗ Could not connect to Jira: {e}")
+            print("  Make sure JIRA_SERVER_URL and JIRA_ACCESS_TOKEN are set")
+    else:
+        print("✗ Jira credentials not configured")
+        print("  Set JIRA_SERVER_URL and JIRA_ACCESS_TOKEN in .env file")
+    
+    print()
+    
+    # Example 4: Team management best practices
+    print("4. Team management best practices")
+    print("-" * 60)
+    print("""
+    Best Practices:
+    
+    1. **Define teams by function**: frontend, backend, devops, qa
+    2. **Keep teams updated**: Use add_team() to update member lists
+    3. **Use meaningful names**: Make team names clear and descriptive
+    4. **Configure per environment**: Different teams for prod vs staging
+    5. **Combine with labels**: Use labels + teams for full visibility
+    
+    Example workflow:
+    
+    1. Configure teams in .env or dynamically
+    2. Create issue with team parameter:
+       create_issue(..., team="frontend")
+    3. All team members automatically become watchers
+    4. Team members receive notifications on updates
+    5. Add/remove individual watchers as needed
+    """)
+    
+    print("=" * 60)
+    print("Example completed!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -429,6 +429,116 @@ class JiraClient:
         except JIRAError as e:
             raise ValueError(f"Failed to get raw fields for issue {issue_key}: {e}")
     
+    async def add_watcher(self, issue_key: str, username: str) -> Dict[str, Any]:
+        """Add a watcher to an issue.
+        
+        Args:
+            issue_key: Jira issue key (e.g., 'PROJ-123')
+            username: Username of the user to add as watcher
+            
+        Returns:
+            Dict containing watcher information
+        """
+        if not self._jira:
+            raise RuntimeError("Not connected to Jira")
+        
+        try:
+            issue = await self._async_call(lambda: self._jira.issue(issue_key))
+            await self._async_call(lambda: self._jira.add_watcher(issue, username))
+            
+            return {
+                'issue_key': issue_key,
+                'watcher': username,
+                'added': True
+            }
+        except JIRAError as e:
+            raise ValueError(f"Failed to add watcher {username} to {issue_key}: {e}")
+    
+    async def remove_watcher(self, issue_key: str, username: str) -> Dict[str, Any]:
+        """Remove a watcher from an issue.
+        
+        Args:
+            issue_key: Jira issue key (e.g., 'PROJ-123')
+            username: Username of the user to remove as watcher
+            
+        Returns:
+            Dict containing watcher information
+        """
+        if not self._jira:
+            raise RuntimeError("Not connected to Jira")
+        
+        try:
+            issue = await self._async_call(lambda: self._jira.issue(issue_key))
+            await self._async_call(lambda: self._jira.remove_watcher(issue, username))
+            
+            return {
+                'issue_key': issue_key,
+                'watcher': username,
+                'removed': True
+            }
+        except JIRAError as e:
+            raise ValueError(f"Failed to remove watcher {username} from {issue_key}: {e}")
+    
+    async def get_watchers(self, issue_key: str) -> List[Dict[str, Any]]:
+        """Get all watchers for an issue.
+        
+        Args:
+            issue_key: Jira issue key (e.g., 'PROJ-123')
+            
+        Returns:
+            List of watchers with their information
+        """
+        if not self._jira:
+            raise RuntimeError("Not connected to Jira")
+        
+        try:
+            watchers_obj = await self._async_call(
+                lambda: self._jira.watchers(issue_key)
+            )
+            
+            return [
+                {
+                    'username': watcher.name,
+                    'display_name': watcher.displayName,
+                    'email': getattr(watcher, 'emailAddress', None),
+                    'active': getattr(watcher, 'active', True)
+                }
+                for watcher in watchers_obj.watchers
+            ]
+        except JIRAError as e:
+            raise ValueError(f"Failed to get watchers for {issue_key}: {e}")
+    
+    async def add_team_as_watchers(self, issue_key: str, team_members: List[str]) -> Dict[str, Any]:
+        """Add multiple team members as watchers to an issue.
+        
+        Args:
+            issue_key: Jira issue key (e.g., 'PROJ-123')
+            team_members: List of usernames to add as watchers
+            
+        Returns:
+            Dict containing success and failure information
+        """
+        if not self._jira:
+            raise RuntimeError("Not connected to Jira")
+        
+        successes = []
+        failures = []
+        
+        for username in team_members:
+            try:
+                await self.add_watcher(issue_key, username)
+                successes.append(username)
+            except Exception as e:
+                failures.append({'username': username, 'error': str(e)})
+        
+        return {
+            'issue_key': issue_key,
+            'successes': successes,
+            'failures': failures,
+            'total_added': len(successes),
+            'total_failed': len(failures)
+        }
+    
     def _extract_custom_field_value(self, field_value):
         """Extract string value from custom field that might be a CustomFieldOption object."""
         if field_value is None:

--- a/jira_mcp_server/config.py
+++ b/jira_mcp_server/config.py
@@ -17,7 +17,8 @@
 """Configuration management for Jira MCP Server."""
 
 import os
-from typing import Optional
+import json
+from typing import Optional, Dict, List
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 
@@ -33,10 +34,35 @@ class JiraConfig(BaseModel):
     verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
     timeout: int = Field(default=30, description="Request timeout in seconds")
     max_results: int = Field(default=100, description="Maximum results per request")
+    teams: Dict[str, List[str]] = Field(default_factory=dict, description="Team definitions mapping team names to member usernames")
+    component_aliases: Dict[str, str] = Field(default_factory=dict, description="Component alias definitions mapping aliases to actual component names")
 
     @classmethod
     def from_env(cls) -> "JiraConfig":
-        """Create configuration from environment variables."""
+        """Create configuration from environment variables.
+        
+        Teams can be configured via JIRA_TEAMS environment variable as JSON:
+        JIRA_TEAMS='{"frontend": ["alice", "bob"], "backend": ["charlie", "david"]}'
+        
+        Component aliases can be configured via JIRA_COMPONENT_ALIASES environment variable as JSON:
+        JIRA_COMPONENT_ALIASES='{"ui": "User Interface", "be": "Backend Services", "infra": "Infrastructure"}'
+        """
+        teams_json = os.getenv("JIRA_TEAMS", "{}")
+        teams = {}
+        try:
+            teams = json.loads(teams_json)
+        except json.JSONDecodeError:
+            # If teams JSON is invalid, just use empty dict
+            pass
+        
+        component_aliases_json = os.getenv("JIRA_COMPONENT_ALIASES", "{}")
+        component_aliases = {}
+        try:
+            component_aliases = json.loads(component_aliases_json)
+        except json.JSONDecodeError:
+            # If component aliases JSON is invalid, just use empty dict
+            pass
+        
         return cls(
             server_url=os.getenv("JIRA_SERVER_URL", ""),
             access_token=os.getenv("JIRA_ACCESS_TOKEN", ""),
@@ -44,6 +70,8 @@ class JiraConfig(BaseModel):
             verify_ssl=os.getenv("JIRA_VERIFY_SSL", "true").lower() == "true",
             timeout=int(os.getenv("JIRA_TIMEOUT", "30")),
             max_results=int(os.getenv("JIRA_MAX_RESULTS", "100")),
+            teams=teams,
+            component_aliases=component_aliases,
         )
 
     def is_cloud(self) -> bool:
@@ -58,3 +86,105 @@ class JiraConfig(BaseModel):
             raise ValueError("JIRA_ACCESS_TOKEN is required")
         if self.is_cloud() and not self.email:
             raise ValueError("JIRA_EMAIL is required for Jira Cloud instances")
+    
+    def get_team_members(self, team_name: str) -> List[str]:
+        """Get members of a team by name.
+        
+        Args:
+            team_name: Name of the team
+            
+        Returns:
+            List of member usernames
+            
+        Raises:
+            ValueError: If team doesn't exist
+        """
+        if team_name not in self.teams:
+            raise ValueError(f"Team '{team_name}' not found. Available teams: {list(self.teams.keys())}")
+        return self.teams[team_name]
+    
+    def add_team(self, team_name: str, members: List[str]) -> None:
+        """Add or update a team.
+        
+        Args:
+            team_name: Name of the team
+            members: List of member usernames
+        """
+        self.teams[team_name] = members
+    
+    def remove_team(self, team_name: str) -> None:
+        """Remove a team.
+        
+        Args:
+            team_name: Name of the team to remove
+            
+        Raises:
+            ValueError: If team doesn't exist
+        """
+        if team_name not in self.teams:
+            raise ValueError(f"Team '{team_name}' not found")
+        del self.teams[team_name]
+    
+    def list_teams(self) -> Dict[str, List[str]]:
+        """List all configured teams.
+        
+        Returns:
+            Dictionary mapping team names to member lists
+        """
+        return self.teams.copy()
+    
+    def get_component_name(self, alias_or_name: str) -> str:
+        """Get the actual component name from an alias or return the name if not an alias.
+        
+        Args:
+            alias_or_name: Component alias or actual component name
+            
+        Returns:
+            Actual component name
+        """
+        # If it's an alias, return the actual name
+        if alias_or_name in self.component_aliases:
+            return self.component_aliases[alias_or_name]
+        # Otherwise return the input as-is (assuming it's the actual component name)
+        return alias_or_name
+    
+    def resolve_component_names(self, aliases_or_names: List[str]) -> List[str]:
+        """Resolve a list of component aliases to actual component names.
+        
+        Args:
+            aliases_or_names: List of component aliases or actual component names
+            
+        Returns:
+            List of actual component names
+        """
+        return [self.get_component_name(item) for item in aliases_or_names]
+    
+    def add_component_alias(self, alias: str, component_name: str) -> None:
+        """Add or update a component alias.
+        
+        Args:
+            alias: Short alias for the component
+            component_name: Actual component name in Jira
+        """
+        self.component_aliases[alias] = component_name
+    
+    def remove_component_alias(self, alias: str) -> None:
+        """Remove a component alias.
+        
+        Args:
+            alias: Alias to remove
+            
+        Raises:
+            ValueError: If alias doesn't exist
+        """
+        if alias not in self.component_aliases:
+            raise ValueError(f"Component alias '{alias}' not found")
+        del self.component_aliases[alias]
+    
+    def list_component_aliases(self) -> Dict[str, str]:
+        """List all configured component aliases.
+        
+        Returns:
+            Dictionary mapping aliases to actual component names
+        """
+        return self.component_aliases.copy()

--- a/tests/test_component_aliases.py
+++ b/tests/test_component_aliases.py
@@ -1,0 +1,300 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for component alias functionality."""
+
+import os
+import json
+import pytest
+from jira_mcp_server.config import JiraConfig
+
+
+class TestComponentAliasConfiguration:
+    """Test component alias configuration in JiraConfig."""
+    
+    def test_component_aliases_from_env(self):
+        """Test loading component aliases from environment variable."""
+        aliases = {
+            "ui": "User Interface",
+            "be": "Backend Services",
+            "infra": "Infrastructure"
+        }
+        os.environ["JIRA_COMPONENT_ALIASES"] = json.dumps(aliases)
+        
+        config = JiraConfig.from_env()
+        
+        assert "ui" in config.component_aliases
+        assert "be" in config.component_aliases
+        assert "infra" in config.component_aliases
+        assert config.component_aliases["ui"] == "User Interface"
+        assert config.component_aliases["be"] == "Backend Services"
+        assert config.component_aliases["infra"] == "Infrastructure"
+    
+    def test_empty_component_aliases_env(self):
+        """Test with empty or missing JIRA_COMPONENT_ALIASES environment variable."""
+        os.environ["JIRA_COMPONENT_ALIASES"] = ""
+        
+        config = JiraConfig.from_env()
+        
+        assert config.component_aliases == {}
+    
+    def test_invalid_component_aliases_json(self):
+        """Test with invalid JSON in JIRA_COMPONENT_ALIASES."""
+        os.environ["JIRA_COMPONENT_ALIASES"] = "invalid json"
+        
+        config = JiraConfig.from_env()
+        
+        # Should default to empty dict on invalid JSON
+        assert config.component_aliases == {}
+    
+    def test_get_component_name_with_alias(self):
+        """Test getting component name from an alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        component_name = config.get_component_name("ui")
+        
+        assert component_name == "User Interface"
+    
+    def test_get_component_name_without_alias(self):
+        """Test getting component name when not an alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        component_name = config.get_component_name("Backend Services")
+        
+        # Should return the input as-is
+        assert component_name == "Backend Services"
+    
+    def test_resolve_component_names(self):
+        """Test resolving a list of component aliases."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={
+                "ui": "User Interface",
+                "be": "Backend Services"
+            }
+        )
+        
+        resolved = config.resolve_component_names(["ui", "be", "Database"])
+        
+        assert resolved == ["User Interface", "Backend Services", "Database"]
+    
+    def test_resolve_component_names_empty_list(self):
+        """Test resolving an empty list."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        resolved = config.resolve_component_names([])
+        
+        assert resolved == []
+    
+    def test_add_component_alias(self):
+        """Test adding a new component alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={}
+        )
+        
+        config.add_component_alias("ui", "User Interface")
+        
+        assert "ui" in config.component_aliases
+        assert config.component_aliases["ui"] == "User Interface"
+    
+    def test_update_component_alias(self):
+        """Test updating an existing component alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        config.add_component_alias("ui", "User Interface v2")
+        
+        assert config.component_aliases["ui"] == "User Interface v2"
+    
+    def test_remove_component_alias(self):
+        """Test removing a component alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface", "be": "Backend Services"}
+        )
+        
+        config.remove_component_alias("ui")
+        
+        assert "ui" not in config.component_aliases
+        assert "be" in config.component_aliases
+    
+    def test_remove_component_alias_not_found(self):
+        """Test removing a non-existent component alias."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={}
+        )
+        
+        with pytest.raises(ValueError) as exc_info:
+            config.remove_component_alias("nonexistent")
+        
+        assert "not found" in str(exc_info.value).lower()
+    
+    def test_list_component_aliases(self):
+        """Test listing all component aliases."""
+        aliases = {
+            "ui": "User Interface",
+            "be": "Backend Services",
+            "infra": "Infrastructure"
+        }
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases=aliases
+        )
+        
+        all_aliases = config.list_component_aliases()
+        
+        assert all_aliases == aliases
+        # Verify it's a copy, not a reference
+        all_aliases["new"] = "New Component"
+        assert "new" not in config.component_aliases
+    
+    def test_multiple_component_aliases(self):
+        """Test managing multiple component aliases."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={}
+        )
+        
+        # Add multiple aliases
+        config.add_component_alias("ui", "User Interface")
+        config.add_component_alias("be", "Backend Services")
+        config.add_component_alias("db", "Database")
+        
+        assert len(config.component_aliases) == 3
+        assert config.get_component_name("ui") == "User Interface"
+        assert config.get_component_name("be") == "Backend Services"
+        assert config.get_component_name("db") == "Database"
+    
+    def test_component_alias_with_spaces(self):
+        """Test component alias with spaces in component name."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={}
+        )
+        
+        config.add_component_alias("frontend", "Frontend User Interface")
+        
+        assert config.get_component_name("frontend") == "Frontend User Interface"
+    
+    def test_component_alias_case_sensitive(self):
+        """Test that component aliases are case-sensitive."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        # Lowercase should be resolved
+        assert config.get_component_name("ui") == "User Interface"
+        
+        # Uppercase should not be resolved (return as-is)
+        assert config.get_component_name("UI") == "UI"
+
+
+class TestComponentAliasIntegration:
+    """Integration tests for component alias management."""
+    
+    def test_component_alias_lifecycle(self):
+        """Test complete lifecycle of component alias configuration."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={}
+        )
+        
+        # Start with no aliases
+        assert len(config.list_component_aliases()) == 0
+        
+        # Add an alias
+        config.add_component_alias("ui", "User Interface")
+        assert len(config.list_component_aliases()) == 1
+        
+        # Update the alias
+        config.add_component_alias("ui", "User Interface v2")
+        assert config.get_component_name("ui") == "User Interface v2"
+        
+        # Add another alias
+        config.add_component_alias("be", "Backend Services")
+        assert len(config.list_component_aliases()) == 2
+        
+        # Remove an alias
+        config.remove_component_alias("ui")
+        assert len(config.list_component_aliases()) == 1
+        assert "be" in config.component_aliases
+    
+    def test_mixed_resolution(self):
+        """Test resolving a mix of aliases and actual component names."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            component_aliases={
+                "ui": "User Interface",
+                "be": "Backend Services"
+            }
+        )
+        
+        # Mix of aliases and actual names
+        components = ["ui", "Database", "be", "Infrastructure"]
+        resolved = config.resolve_component_names(components)
+        
+        assert resolved == [
+            "User Interface",  # ui -> User Interface
+            "Database",        # No alias, returned as-is
+            "Backend Services", # be -> Backend Services
+            "Infrastructure"   # No alias, returned as-is
+        ]
+    
+    def test_teams_and_aliases_coexist(self):
+        """Test that teams and component aliases can coexist."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={"frontend": ["alice", "bob"]},
+            component_aliases={"ui": "User Interface"}
+        )
+        
+        # Test teams functionality
+        assert config.get_team_members("frontend") == ["alice", "bob"]
+        
+        # Test component aliases functionality
+        assert config.get_component_name("ui") == "User Interface"
+        
+        # Both should be independent
+        assert len(config.teams) == 1
+        assert len(config.component_aliases) == 1
+

--- a/tests/test_team_management.py
+++ b/tests/test_team_management.py
@@ -1,0 +1,216 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for team management functionality."""
+
+import os
+import json
+import pytest
+from jira_mcp_server.config import JiraConfig
+
+
+class TestTeamConfiguration:
+    """Test team configuration in JiraConfig."""
+    
+    def test_teams_from_env(self):
+        """Test loading teams from environment variable."""
+        teams = {
+            "frontend": ["alice", "bob"],
+            "backend": ["charlie", "david"]
+        }
+        os.environ["JIRA_TEAMS"] = json.dumps(teams)
+        
+        config = JiraConfig.from_env()
+        
+        assert "frontend" in config.teams
+        assert "backend" in config.teams
+        assert config.teams["frontend"] == ["alice", "bob"]
+        assert config.teams["backend"] == ["charlie", "david"]
+    
+    def test_empty_teams_env(self):
+        """Test with empty or missing JIRA_TEAMS environment variable."""
+        os.environ["JIRA_TEAMS"] = ""
+        
+        config = JiraConfig.from_env()
+        
+        assert config.teams == {}
+    
+    def test_invalid_teams_json(self):
+        """Test with invalid JSON in JIRA_TEAMS."""
+        os.environ["JIRA_TEAMS"] = "invalid json"
+        
+        config = JiraConfig.from_env()
+        
+        # Should default to empty dict on invalid JSON
+        assert config.teams == {}
+    
+    def test_get_team_members(self):
+        """Test getting team members."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={"frontend": ["alice", "bob"]}
+        )
+        
+        members = config.get_team_members("frontend")
+        
+        assert members == ["alice", "bob"]
+    
+    def test_get_team_members_not_found(self):
+        """Test getting members of non-existent team."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={"frontend": ["alice", "bob"]}
+        )
+        
+        with pytest.raises(ValueError) as exc_info:
+            config.get_team_members("nonexistent")
+        
+        assert "not found" in str(exc_info.value).lower()
+        assert "frontend" in str(exc_info.value)
+    
+    def test_add_team(self):
+        """Test adding a new team."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={}
+        )
+        
+        config.add_team("devops", ["eve", "frank"])
+        
+        assert "devops" in config.teams
+        assert config.teams["devops"] == ["eve", "frank"]
+    
+    def test_update_team(self):
+        """Test updating an existing team."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={"frontend": ["alice", "bob"]}
+        )
+        
+        config.add_team("frontend", ["alice", "bob", "grace"])
+        
+        assert config.teams["frontend"] == ["alice", "bob", "grace"]
+    
+    def test_remove_team(self):
+        """Test removing a team."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={"frontend": ["alice", "bob"], "backend": ["charlie"]}
+        )
+        
+        config.remove_team("frontend")
+        
+        assert "frontend" not in config.teams
+        assert "backend" in config.teams
+    
+    def test_remove_team_not_found(self):
+        """Test removing a non-existent team."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={}
+        )
+        
+        with pytest.raises(ValueError) as exc_info:
+            config.remove_team("nonexistent")
+        
+        assert "not found" in str(exc_info.value).lower()
+    
+    def test_list_teams(self):
+        """Test listing all teams."""
+        teams = {
+            "frontend": ["alice", "bob"],
+            "backend": ["charlie", "david"]
+        }
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams=teams
+        )
+        
+        all_teams = config.list_teams()
+        
+        assert all_teams == teams
+        # Verify it's a copy, not a reference
+        all_teams["newteam"] = ["someone"]
+        assert "newteam" not in config.teams
+    
+    def test_multiple_teams(self):
+        """Test managing multiple teams."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={}
+        )
+        
+        # Add multiple teams
+        config.add_team("frontend", ["alice", "bob"])
+        config.add_team("backend", ["charlie", "david"])
+        config.add_team("devops", ["eve"])
+        
+        assert len(config.teams) == 3
+        assert config.get_team_members("frontend") == ["alice", "bob"]
+        assert config.get_team_members("backend") == ["charlie", "david"]
+        assert config.get_team_members("devops") == ["eve"]
+    
+    def test_team_with_empty_members(self):
+        """Test team with empty member list."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={}
+        )
+        
+        config.add_team("empty-team", [])
+        
+        assert "empty-team" in config.teams
+        assert config.teams["empty-team"] == []
+
+
+class TestTeamIntegration:
+    """Integration tests for team management (requires mocking or real Jira instance)."""
+    
+    def test_team_configuration_lifecycle(self):
+        """Test complete lifecycle of team configuration."""
+        config = JiraConfig(
+            server_url="https://test.atlassian.net",
+            access_token="test-token",
+            teams={}
+        )
+        
+        # Start with no teams
+        assert len(config.list_teams()) == 0
+        
+        # Add a team
+        config.add_team("team1", ["user1", "user2"])
+        assert len(config.list_teams()) == 1
+        
+        # Update the team
+        config.add_team("team1", ["user1", "user2", "user3"])
+        assert len(config.get_team_members("team1")) == 3
+        
+        # Add another team
+        config.add_team("team2", ["user4"])
+        assert len(config.list_teams()) == 2
+        
+        # Remove a team
+        config.remove_team("team1")
+        assert len(config.list_teams()) == 1
+        assert "team2" in config.teams
+


### PR DESCRIPTION
# Add Team Management and Watcher Functionality

## Summary
This PR adds comprehensive team management functionality to the Jira MCP Server, enabling users to define teams and assign entire teams to Jira issues where all members automatically become watchers.

## What's New
- **Team Management**: Define teams with multiple members and manage them via CRUD operations
- **Automatic Watcher Assignment**: Assign entire teams to issues in one operation instead of managing individual watchers
- **7 New MCP Tools**:
  - `assign_team_to_issue`
  - `add_watcher_to_issue`
  - `remove_watcher_from_issue`
  - `get_issue_watchers`
  - `list_teams`
  - `add_team`
  - `remove_team`

## Configuration Options
Teams can be configured in two ways:
1. **Static**: Via `JIRA_TEAMS` environment variable (JSON format: `{"team_name": ["user1", "user2"]}`)
2. **Dynamic**: Using runtime API methods for managing teams on-the-fly

## Technical Changes
- Modified `config.py`, `client.py`, and `server.py` to support team operations and watcher management
- Fully backward-compatible with no breaking changes

## Documentation & Testing
- Comprehensive documentation in `TEAM_MANAGEMENT.md` and `TEAM_QUICKSTART.md`
- Example scripts in `examples/team_management_example.py`
- Unit tests added for team functionality

## Benefits
Simplifies collaboration workflows by allowing teams to be notified about issue updates collectively rather than managing individual watchers manually.