### PR TITLE
Enable CodeRabbit for automated PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+  auto_title_placeholder: "@coderabbitai"
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  sequence_diagrams: true
+  changed_files_summary: true
+  labeling_instructions: []
+  path_filters:
+    - "!**/*.lock"
+    - "!**/*.md"
+    - "!doc/**"
+    - "!examples/**"
+  path_instructions:
+    - path: "jira_mcp_server/server.py"
+      instructions: |
+        This is the MCP server definition with all tool registrations.
+        Pay close attention to:
+        - Correct parameter validation and types
+        - Proper error handling for Jira API calls
+        - Security: no credential leakage in error messages or logs
+        - Rate limiting compliance
+    - path: "jira_mcp_server/client.py"
+      instructions: |
+        This is the async Jira API client with rate limiting.
+        Review for:
+        - Proper async/await usage
+        - Rate limiting correctness
+        - Error handling and retries
+        - No blocking calls in async context
+    - path: "jira_mcp_server/config.py"
+      instructions: |
+        Pydantic configuration models.
+        Ensure:
+        - Sensitive fields (tokens, passwords) are not exposed in repr/logs
+        - Validation rules are correct
+        - Defaults are sensible
+    - path: "tests/**"
+      instructions: |
+        Review tests for:
+        - Adequate coverage of edge cases
+        - Proper use of pytest fixtures and pytest-asyncio
+        - No hardcoded credentials or real Jira URLs
+  tools:
+    ruff:
+      enabled: true
+    shellcheck:
+      enabled: true
+    mypy:
+      enabled: true
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  learnings:
+    scope: auto
+  jira:
+    project_keys: []
+  linear:
+    team_keys: []

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,8 +54,6 @@ reviews:
       enabled: true
     shellcheck:
       enabled: true
-    mypy:
-      enabled: true
 
 chat:
   auto_reply: true


### PR DESCRIPTION
  - Add .coderabbit.yaml with chill review profile
  - Configure path-specific review instructions for server.py, client.py, config.py, and tests
  - Enable Ruff, ShellCheck, and Mypy tool integrations
  - Exclude lock files, markdown, /doc, and /examples from reviews
  - Enable high-level summaries and sequence diagrams for PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a code-review automation configuration to standardize review behavior and tooling, including language/profile defaults, review summaries, path-based filters, test guidance, tool checks, automated responses, and knowledge-base structure for future learnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->