### PR TITLE
Enhance jira-create command with interactive flow and make estimate fields optional

### DIFF
--- a/.claude/commands/jira-create.md
+++ b/.claude/commands/jira-create.md
@@ -1,57 +1,122 @@
 # Jira Create Command
 
-This command helps you create a new Jira issue by prompting for all necessary information and using the Jira MCP server.
+Create a new Jira issue interactively using `AskUserQuestion` to collect all required and optional fields.
 
-## Usage
+## Instructions
 
-Type `/jira-create` or `/jira create` to start the interactive issue creation process.
+Follow these steps in order. Use `AskUserQuestion` for each step. Do NOT skip steps or guess values.
 
-## What this command does
+### Step 1: Issue Type
 
-1. **Prompts for required information:**
-   - Issue summary/title
-   - Detailed description
-   - Project key (defaults to "ACM")
-   - Priority level (defaults to Normal)
-   - Security level (defaults to "Red Hat Employee")
-   - **Parent issue** (if creating sub-task)
-   - Due date (YYYY-MM-DD format)
-   - Components (with intelligent suggestions)
-   - Labels (including Train-* labels)
-   - Fix version/target release
-   - Assignee (suggests "assign to me")
-   - Work type
-   - Original time estimate
-   - Story points
-   - Target Start (defaults to today's date)
-   - Components
+Use `AskUserQuestion` to ask the user what type of issue to create:
 
-## Component Intelligence
+- **Story** — User-facing functionality with acceptance criteria
+- **Bug** — Defect report with reproduction steps
+- **Task** — Internal technical work, non-user-facing
+- **Spike** — Research, investigation, or proof-of-concept
+- **Feature** — Significant customer-facing capability
+- **Epic** — Large body of work spanning multiple sprints
+- **Sub-task** — Child task under an existing issue
 
-The command automatically suggests appropriate components based on keywords:
-- "virtualization", "vm", "kubevirt" → "Container Native Virtualization"
-- "observability", "monitoring", "metrics" → "Observability"
-- "multicluster", "cluster management" → "Multicluster"
-- "policy", "governance" → "Governance"
-- "applications", "app management" → "Application Management"
-- "infrastructure", "bare metal" → "Infrastructure"
-- "search", "console" → "Search"
+### Step 2: Delegate to Specialist Agent
 
-**Sub-task Inheritance:**
-- Sub-tasks automatically inherit the project from their parent
-- Components, labels, and fix versions can be inherited or set independently
-- The parent issue key is automatically set in the `parent` field
+Based on the issue type selected, launch the appropriate specialist agent to help craft the content. The agent should help formulate the summary, description, and any type-specific fields:
 
-**Validation:**
-- Ensures the parent issue exists before creating the sub-task
-- Validates that the parent issue is not already a sub-task (sub-tasks can't have sub-tasks)
+| Issue Type | Agent | Purpose |
+|------------|-------|---------|
+| Story | `story-specialist` | Craft user story format, acceptance criteria, definition of done |
+| Bug | `bug-specialist` | Structure reproduction steps, expected vs actual behavior, severity |
+| Task | `task-specialist` | Technical breakdown, implementation details |
+| Spike | `spike-specialist` | Research questions, success criteria, time-box |
+| Feature | `feature-specialist` | Feature strategy, user impact, rollout plan |
+| Epic | `epic-specialist` | Epic scope, child story breakdown, cross-team coordination |
+| Sub-task | `task-specialist` | Scoped sub-task breakdown |
+
+The agent should return a proposed **summary** and **description**. Present them to the user for approval or editing via `AskUserQuestion`.
+
+### Step 3: Collect Core Fields
+
+Use `AskUserQuestion` to collect the remaining fields. Group questions logically (up to 4 questions per call). You may batch related fields together.
+
+**Priority** (default: Normal):
+- Blocker
+- Critical
+- Major
+- Normal (Recommended)
+- Minor
+- Trivial
+
+**Work Type** (submit as ID number):
+- None = -1
+- Associate Wellness & Development = 46650
+- Future Sustainability = 48051
+- Incident & Support = 46651
+- Quality / Stability / Reliability = 46653
+- Security & Compliance = 46652
+- Product / Portfolio Work = 46654
+
+**Original Estimate** (e.g., '2h', '1d', '30m')
+
+**Story Points** (default: 1) — MUST always be prompted for via `AskUserQuestion`. If the user does not provide a value, use 1.
+
+### Step 4: Collect Categorization Fields
+
+Use `AskUserQuestion` to collect:
+
+**Component** — Present the top relevant components from the ACM project. Suggest based on keywords in the summary/description. Common components include:
+- Search
+- Console
+- GRC
+- Cluster Lifecycle
+- Observability
+- HyperShift
+- Installer
+- Server Foundation
+- Application Lifecycle
+- Infrastructure Operator
+- DevOps
+- Global Hub
+- Multicluster Networking
+- Business Continuity
+- Container Native Virtualization
+- Edge
+- Documentation
+
+**Labels** — Ask if they want to add any labels (free text, comma-separated).
+
+**Target Version** — Ask for the target version (e.g., "ACM 2.16.0").
+
+### Step 5: Parent / Linking
+
+Use `AskUserQuestion` to ask if there is a parent or related issue.
+
+- If **Sub-task**: Ask for the parent issue key (required). Set the `parent` field on `create_issue`.
+- If **any other type** and a parent is provided: Create the issue first, then use `link_issue` to link it to the parent with an appropriate link type (e.g., "Blocks", "Depend", "Related", "Incorporates"). Ask the user which link type to use.
+- If **Epic**: Ask for an `epic_name` (required for Epics).
+
+### Step 6: Confirm and Create
+
+Before calling `create_issue`, display a summary of ALL fields to the user and ask for confirmation.
+
+Always set:
+- `project_key`: "ACM"
+- `security_level`: "Red Hat Employee"
+- `assignee`: "jpacker@redhat.com"
+
+Call `create_issue` with all collected fields.
+
+After creation, if linking is needed (non-sub-task with a parent), call `link_issue`.
+
+### Step 7: Post-Creation
+
+After successful creation:
+1. Display the created issue key and link
+2. If this is an Epic, ask if the user wants to create child stories/tasks now
+3. If this is a Feature, ask if the user wants to create related epics or stories
 
 ## Error Handling
 
-The command validates:
-- Date formats (YYYY-MM-DD)
-- Time estimates (whole numbers only)
-- Git commit SHAs (40 or 64 hex characters)
-- Required field completion
-
-If errors occur, helpful suggestions will be provided for correction.
+- Validate date formats (YYYY-MM-DD)
+- Validate time estimates use Jira format (e.g., '1h 30m', '2d')
+- If `create_issue` fails, show the error and ask the user what to fix
+- Never retry creation without user confirmation

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -310,8 +310,8 @@ class JiraMCPServer:
             security_level: Optional[str] = "Red Hat Employee",
             target_start: Optional[str] = None,
             target_end: Optional[str] = None,
-            original_estimate: Optional[str] = "1h",
-            story_points: Optional[float] = 1,
+            original_estimate: Optional[str] = None,
+            story_points: Optional[float] = None,
             git_commit: Optional[str] = None,
             git_pull_requests: Optional[str] = None,
             parent: Optional[str] = None,
@@ -347,8 +347,8 @@ class JiraMCPServer:
                 target_start: Target start date in YYYY-MM-DD format
                 target_end: Target end date in YYYY-MM-DD format
                 components: List of component names (STRONGLY RECOMMENDED)
-                original_estimate: Original time estimate (e.g., '1h 30m')
-                story_points: Story points value
+                original_estimate: Original time estimate (e.g., '1h 30m'). RECOMMENDED for better estimation tracking.
+                story_points: Story points value. RECOMMENDED for better sprint planning.
                 git_commit: Git commit hash or reference
                 git_pull_requests: Git pull requests, comma separated list of pull requests URLs
                 parent: Parent issue key for sub-tasks (e.g., 'PROJ-123')


### PR DESCRIPTION

  - Rewrite jira-create.md with step-by-step interactive flow, specialist agent delegation, structured field collection, and post-creation actions
  - Change original_estimate default from 1h to None
  - Change story_points default from 1 to None
  - Update docstrings to mark both fields as RECOMMENDED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Made original_estimate and story_points parameters fully optional when creating issues (previously had default values).

* **Documentation**
  * Enhanced help text to clearly identify original_estimate and story_points as recommended fields for improved user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->