### PR TITLE
Feat: Partial improvements to update, clearing fields, /myissues command, new tests.

### DIFF
--- a/.claude/commands/myissues.md
+++ b/.claude/commands/myissues.md
@@ -1,0 +1,61 @@
+# My Issues Command
+
+Show a table of all my Jira issues for a specific ACM release version.
+
+## Instructions
+
+### Step 1: Determine ACM Version
+
+Check if a version was already selected earlier in this conversation (from a previous `/myissues` invocation). If so, reuse that version silently — do NOT prompt again.
+
+Only use `AskUserQuestion` to ask for the version if:
+- This is the first time `/myissues` is run in this session, OR
+- The user explicitly asks to change the version (e.g., "show me 2.16.0 issues", "switch to ACM 2.18.0")
+
+When prompting, pre-fill with the most likely current version based on context. If CLAUDE.md mentions a `fix_version`, use the next minor version as the default guess (e.g., if fix_version is "ACM 2.16.0", guess "ACM 2.17.0"). Common options:
+
+- ACM 2.17.0 (Recommended)
+- ACM 2.16.0
+- ACM 2.18.0
+
+### Step 2: Search for Issues
+
+Run TWO parallel Jira searches using `search_issues`:
+
+**Query 1 — Fix Version:**
+```
+project = ACM AND fixVersion = "<version>" AND (assignee = "jpacker@redhat.com" OR reporter = "jpacker@redhat.com") ORDER BY status ASC, priority DESC
+```
+
+**Query 2 — Target Version:**
+```
+project = ACM AND "Target Version" = "<version>" AND (assignee = "jpacker@redhat.com" OR reporter = "jpacker@redhat.com") ORDER BY status ASC, priority DESC
+```
+
+Merge the results, deduplicating by issue key.
+
+### Step 3: Check for Recently Worked Issues
+
+Before rendering the table, review the current conversation history. If you performed actions on any issues earlier in this session (e.g., added comments, transitioned, updated, summarized, created tasks for, or otherwise interacted with an issue), then:
+
+1. Note which issues were worked on
+2. **Exclude them from the table**
+3. State clearly at the top: "Excluded issues worked on in this session: ACM-XXXXX, ACM-YYYYY"
+
+This keeps the table focused on issues that still need attention.
+
+### Step 4: Render the Table
+
+Present the results as a markdown table with these columns:
+
+| Key | Type | Summary | Status | Priority | Fix Version | Target Version |
+
+Sort by: Status ASC (New first, then In Progress, then Closed), then Priority DESC (Critical first).
+
+Add a summary line at the bottom with total counts by status.
+
+### Notes
+
+- Always quote email addresses in JQL to avoid the reserved `@` character error
+- The "Target Version" field in JQL must be quoted as `"Target Version"` (not `targetVersion`)
+- If both searches return no results, inform the user that no issues were found for that version

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,22 @@
 
 SHELL := /bin/bash
 
-.PHONY: help tests
+.PHONY: help test tests install-commands
 
 .DEFAULT_GOAL := help
 
 help:
 	@echo "Jira MCP Server - Available targets:"
 	@echo ""
-	@echo "  tests - Run all tests in the tests/ directory"
-	@echo "  help  - Show this help message"
+	@echo "  test             - Run all tests in the tests/ directory"
+	@echo "  tests            - Alias for test"
+	@echo "  install-commands - Symlink project commands to ~/.claude/commands/"
+	@echo "  help             - Show this help message"
 
-tests:
+test tests:
 	python3 -m pytest tests/ -v
+
+install-commands:
+	@mkdir -p $(HOME)/.claude/commands
+	@ln -sf $(CURDIR)/.claude/commands/jira-create.md $(HOME)/.claude/commands/jira-create.md
+	@echo "Symlinked jira-create.md to ~/.claude/commands/"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ test tests:
 	python3 -m pytest tests/ -v
 
 install-commands:
-	@mkdir -p $(HOME)/.claude/commands
-	@ln -sf $(CURDIR)/.claude/commands/jira-create.md $(HOME)/.claude/commands/jira-create.md
-	@echo "Symlinked jira-create.md to ~/.claude/commands/"
+	`@mkdir` -p "$(HOME)/.claude/commands"
+	`@for` cmd in "$(CURDIR)"/.claude/commands/*.md; do \
+		name="$$(basename "$$cmd")"; \
+		ln -sf "$$cmd" "$(HOME)/.claude/commands/$$name"; \
+		echo "Symlinked $$name to ~/.claude/commands/"; \
+	done

--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ A Model Context Protocol (MCP) server that provides seamless integration with Ji
 4. [Usage](#usage)
 5. [Client Configuration](#client-configuration)
 6. [Available Tools](#available-tools)
-7. [Development](#development)
-8. [Troubleshooting](#troubleshooting)
-9. [Advanced Configuration](#advanced-configuration)
-10. [License & Contributing](#license--contributing)
+7. [Slash Commands](#slash-commands)
+8. [Automatic Update Notifications](#automatic-update-notifications)
+9. [Development](#development)
+10. [Troubleshooting](#troubleshooting)
+11. [Advanced Configuration](#advanced-configuration)
+12. [License & Contributing](#license--contributing)
 
 ## Features
 
@@ -530,7 +532,49 @@ The server also provides MCP resources for read-only access:
 - `jira://issue/{issue_key}` - Get formatted issue details
 - `jira://projects` - Get formatted list of all projects
 
+## Slash Commands
+
+The project includes custom slash commands that can be installed for use in Claude Code.
+
+### `/jira-create` — Interactive Issue Creation
+
+The `/jira-create` command provides a guided, interactive flow for creating Jira issues. It walks you through each step using prompts:
+
+1. **Issue Type** — Select from Story, Bug, Task, Spike, Feature, Epic, or Sub-task
+2. **Specialist Agent** — A specialist agent (e.g., `story-specialist`, `bug-specialist`) is launched to help craft the summary and description based on the issue type
+3. **Core Fields** — Priority, Work Type, Original Estimate, Story Points
+4. **Categorization** — Component, Labels, Target Version
+5. **Parent / Linking** — Link to a parent issue or related issues
+6. **Confirmation** — Review all fields before creation
+7. **Post-Creation** — Option to create child stories (for Epics) or related issues (for Features)
+
+To install the command:
+
+```bash
+make install-commands
+```
+
+This symlinks the command to `~/.claude/commands/` so it's available globally in Claude Code. You can then invoke it by typing `/jira-create` in any Claude Code session.
+
+## Automatic Update Notifications
+
+The server automatically checks for updates when it starts. It compares your local checkout against `origin/main` and, if new commits are available, emits a one-time warning on the first tool call of the session:
+
+```
+jira-mcp-server update available: origin/main is 3 commit(s) ahead. Run 'git pull' in /path/to/jira-mcp-server to update.
+```
+
+This check is non-blocking and fails silently if the repository is not available or the fetch times out.
+
 ## Development
+
+### Makefile Targets
+
+```bash
+make help              # Show available targets
+make tests             # Run all tests in the tests/ directory
+make install-commands  # Symlink project commands to ~/.claude/commands/
+```
 
 ### Running Tests
 

--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -460,6 +460,24 @@ class JiraClient:
         except JIRAError as e:
             raise ValueError(f"Failed to get raw fields for issue {issue_key}: {e}")
     
+    async def get_editmeta(self, issue_key: str) -> Dict[str, Any]:
+        """Get edit metadata for an issue, describing each editable field's schema.
+
+        Returns a dict mapping field IDs to their schema info (name, type, items, etc.).
+        """
+        if not self._jira:
+            raise RuntimeError("Not connected to Jira")
+
+        try:
+            url = f"{self._jira._options['server']}/rest/api/2/issue/{issue_key}/editmeta"
+            response = await self._async_call(
+                lambda: self._jira._session.get(url)
+            )
+            data = response.json()
+            return data.get('fields', {})
+        except JIRAError as e:
+            raise ValueError(f"Failed to get edit metadata for {issue_key}: {e}")
+
     async def add_watcher(self, issue_key: str, username: str) -> Dict[str, Any]:
         """Add a watcher to an issue.
         

--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -473,10 +473,12 @@ class JiraClient:
             response = await self._async_call(
                 lambda: self._jira._session.get(url)
             )
+            if not response.ok:
+                raise ValueError(f"Failed to get edit metadata for {issue_key}: HTTP {response.status_code}")
             data = response.json()
             return data.get('fields', {})
         except JIRAError as e:
-            raise ValueError(f"Failed to get edit metadata for {issue_key}: {e}")
+            raise ValueError(f"Failed to get edit metadata for {issue_key}: {e}") from e
 
     async def add_watcher(self, issue_key: str, username: str) -> Dict[str, Any]:
         """Add a watcher to an issue.

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -18,7 +18,9 @@
 
 import asyncio
 import logging
+import os
 import re
+import subprocess
 from typing import List, Dict, Any, Optional
 from fastmcp import FastMCP, Context
 from pydantic import BaseModel
@@ -178,6 +180,8 @@ class JiraMCPServer:
         self.mcp = FastMCP("Jira MCP Server")
         self.config = JiraConfig.from_env()
         self.client = JiraClient(self.config)
+        self._update_warning: Optional[str] = None
+        self._update_warning_emitted = False
         self._setup_tools()
         self._setup_resources()
     
@@ -197,6 +201,7 @@ class JiraMCPServer:
                 max_results: Maximum number of results to return (default: 100)
                 ctx: MCP context for progress reporting
             """
+            await self._emit_update_warning(ctx)
             if ctx:
                 await ctx.info(f"Searching issues with JQL: {jql}")
             
@@ -230,6 +235,7 @@ class JiraMCPServer:
                 max_results: Maximum number of results to return (default: 100)
                 ctx: MCP context for progress reporting
             """
+            await self._emit_update_warning(ctx)
             if ctx:
                 await ctx.info(f"Searching issues assigned to team '{team_name}'")
             
@@ -281,6 +287,7 @@ class JiraMCPServer:
                 issue_key: Jira issue key (e.g., 'PROJ-123')
                 ctx: MCP context for progress reporting
             """
+            await self._emit_update_warning(ctx)
             if ctx:
                 await ctx.info(f"Fetching issue: {issue_key}")
             
@@ -367,6 +374,7 @@ class JiraMCPServer:
             if fix_versions is not None and (not fix_versions or len(fix_versions) == 0):
                 raise ValueError("Fix versions cannot be empty")
 
+            await self._emit_update_warning(ctx)
             if ctx:
                 await ctx.info(f"Creating issue in project {project_key}")
 
@@ -548,6 +556,72 @@ class JiraMCPServer:
                     await ctx.error(f"Failed to update issue {issue_key}: {str(e)}")
                 raise
         
+        @self.mcp.tool()
+        async def clear_field(
+            issue_key: str,
+            field_name: str,
+            ctx: Optional[Context] = None
+        ) -> IssueResponse:
+            """Clear (unset) a field on a Jira issue.
+
+            Dynamically determines the correct empty value by inspecting the
+            field's schema from the Jira edit metadata.
+
+            Args:
+                issue_key: Jira issue key (e.g., 'PROJ-123')
+                field_name: The Jira field ID to clear (e.g., 'fixVersions',
+                    'customfield_12319940', 'duedate', 'labels', 'components',
+                    'assignee', 'priority', 'security', 'timetracking').
+                    Use the debug_issue_fields tool to discover available field IDs.
+                ctx: MCP context for progress reporting
+            """
+            if ctx:
+                await ctx.info(f"Fetching edit metadata for {issue_key}")
+
+            editmeta = await self.client.get_editmeta(issue_key)
+
+            if field_name not in editmeta:
+                available = ', '.join(sorted(editmeta.keys()))
+                raise ValueError(
+                    f"Field '{field_name}' is not editable on {issue_key}. "
+                    f"Editable fields: {available}"
+                )
+
+            schema = editmeta[field_name].get('schema', {})
+            field_type = schema.get('type', '')
+
+            # Determine the correct clear value based on schema type
+            if field_type == 'array':
+                clear_value = []
+            elif field_type in ('string', 'date', 'datetime'):
+                clear_value = None
+            elif field_type == 'number':
+                clear_value = None
+            elif field_type == 'timetracking':
+                clear_value = {'originalEstimate': '0m'}
+            else:
+                # option, user, security, priority, issuelink, etc.
+                clear_value = None
+
+            if ctx:
+                await ctx.info(
+                    f"Clearing '{field_name}' (type={field_type}) on {issue_key}"
+                )
+
+            try:
+                issue = await self.client.update_issue(
+                    issue_key, **{field_name: clear_value}
+                )
+                if ctx:
+                    await ctx.info(f"Cleared '{field_name}' on {issue_key}")
+                return IssueResponse(**issue)
+            except Exception as e:
+                if ctx:
+                    await ctx.error(
+                        f"Failed to clear '{field_name}' on {issue_key}: {str(e)}"
+                    )
+                raise
+
         @self.mcp.tool()
         async def transition_issue(
             issue_key: str,
@@ -1130,6 +1204,43 @@ class JiraMCPServer:
             except Exception as e:
                 return f"Error fetching projects: {str(e)}"
     
+    async def _check_for_updates(self) -> None:
+        """Check if origin/main has commits not present locally."""
+        try:
+            # Find the repo root (server may be installed anywhere)
+            repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            git_dir = os.path.join(repo_dir, ".git")
+            if not os.path.isdir(git_dir):
+                return
+
+            # Fetch latest refs from origin (quiet, no output)
+            subprocess.run(
+                ["git", "fetch", "origin", "main", "--quiet"],
+                cwd=repo_dir, capture_output=True, timeout=10
+            )
+
+            # Count commits on origin/main that are not in local HEAD
+            result = subprocess.run(
+                ["git", "rev-list", "HEAD..origin/main", "--count"],
+                cwd=repo_dir, capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0:
+                count = int(result.stdout.strip())
+                if count > 0:
+                    self._update_warning = (
+                        f"jira-mcp-server update available: origin/main is {count} "
+                        f"commit(s) ahead. Run 'git pull' in {repo_dir} to update."
+                    )
+                    logger.warning(self._update_warning)
+        except Exception as e:
+            logger.debug(f"Update check failed (non-fatal): {e}")
+
+    async def _emit_update_warning(self, ctx: Optional[Context]) -> None:
+        """Emit update warning once per session via MCP context."""
+        if self._update_warning and not self._update_warning_emitted and ctx:
+            await ctx.warning(self._update_warning)
+            self._update_warning_emitted = True
+
     async def start(self) -> None:
         """Start the MCP server."""
         try:
@@ -1137,6 +1248,7 @@ class JiraMCPServer:
             await self.client.connect()
             logger.info("Connected to Jira successfully")
             logger.info(f"Server URL: {self.config.server_url}")
+            await self._check_for_updates()
         except Exception as e:
             logger.error(f"Failed to start server: {e}")
             raise

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,131 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file was developed with AI assistance.
+
+"""Tests for automatic update check functionality."""
+
+import os
+import subprocess
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from jira_mcp_server.server import JiraMCPServer
+
+
+@pytest.fixture
+def server():
+    """Create a JiraMCPServer instance with mocked dependencies."""
+    with patch.dict(os.environ, {
+        'JIRA_SERVER_URL': 'https://test.atlassian.net',
+        'JIRA_ACCESS_TOKEN': 'test-token',
+    }):
+        srv = JiraMCPServer()
+        return srv
+
+
+@pytest.mark.asyncio
+async def test_update_check_sets_warning_when_behind(server):
+    """When origin/main is ahead, _update_warning should be set."""
+    fetch_result = MagicMock(returncode=0)
+    count_result = MagicMock(returncode=0, stdout="3\n")
+
+    with patch("jira_mcp_server.server.os.path.isdir", return_value=True), \
+         patch("jira_mcp_server.server.subprocess.run", side_effect=[fetch_result, count_result]):
+        await server._check_for_updates()
+
+    assert server._update_warning is not None
+    assert "3 commit(s) ahead" in server._update_warning
+
+
+@pytest.mark.asyncio
+async def test_update_check_no_warning_when_up_to_date(server):
+    """When local is up to date, no warning should be set."""
+    fetch_result = MagicMock(returncode=0)
+    count_result = MagicMock(returncode=0, stdout="0\n")
+
+    with patch("jira_mcp_server.server.os.path.isdir", return_value=True), \
+         patch("jira_mcp_server.server.subprocess.run", side_effect=[fetch_result, count_result]):
+        await server._check_for_updates()
+
+    assert server._update_warning is None
+
+
+@pytest.mark.asyncio
+async def test_update_check_no_git_dir(server):
+    """When .git directory does not exist, skip silently."""
+    with patch("jira_mcp_server.server.os.path.isdir", return_value=False), \
+         patch("jira_mcp_server.server.subprocess.run") as mock_run:
+        await server._check_for_updates()
+
+    mock_run.assert_not_called()
+    assert server._update_warning is None
+
+
+@pytest.mark.asyncio
+async def test_update_check_handles_fetch_failure(server):
+    """If git fetch fails, no warning and no crash."""
+    with patch("jira_mcp_server.server.os.path.isdir", return_value=True), \
+         patch("jira_mcp_server.server.subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
+        await server._check_for_updates()
+
+    assert server._update_warning is None
+
+
+@pytest.mark.asyncio
+async def test_update_check_handles_rev_list_failure(server):
+    """If rev-list returns non-zero, no warning."""
+    fetch_result = MagicMock(returncode=0)
+    count_result = MagicMock(returncode=128, stdout="")
+
+    with patch("jira_mcp_server.server.os.path.isdir", return_value=True), \
+         patch("jira_mcp_server.server.subprocess.run", side_effect=[fetch_result, count_result]):
+        await server._check_for_updates()
+
+    assert server._update_warning is None
+
+
+@pytest.mark.asyncio
+async def test_emit_warning_once(server):
+    """Warning should be emitted via ctx.warning only once."""
+    server._update_warning = "update available"
+
+    ctx = AsyncMock()
+
+    await server._emit_update_warning(ctx)
+    ctx.warning.assert_called_once_with("update available")
+    assert server._update_warning_emitted is True
+
+    # Second call should not emit again
+    ctx.reset_mock()
+    await server._emit_update_warning(ctx)
+    ctx.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_warning_skipped_when_no_warning(server):
+    """No ctx.warning call when there is no update warning."""
+    ctx = AsyncMock()
+
+    await server._emit_update_warning(ctx)
+    ctx.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_warning_skipped_when_no_ctx(server):
+    """No crash when ctx is None."""
+    server._update_warning = "update available"
+
+    await server._emit_update_warning(None)
+    assert server._update_warning_emitted is False


### PR DESCRIPTION
 1. New Slash Command: myissues (.claude/commands/myissues.md)
  - Interactive command to list your Jira issues for specific ACM release versions
  - Searches by both fix version and target version
  - Excludes issues you worked on in the current session

  2. Makefile Improvements
  - Added install-commands target to symlink project commands to ~/.claude/commands/
  - Added test alias for tests target
  - Better-organized help message with alignment

  3. README.md Updates
  - Added documentation for the new jira-create slash command
  - Added new Slash Commands section
  - Added Automatic Update Notifications section
  - Updated development section with Makefile targets

  4. Jira Client Enhancement (jira_mcp_server/client.py)
  - New get_editmeta() method to fetch edit metadata for an issue
  - Required for the new clear_field tool

  5. Server Features (jira_mcp_server/server.py)
  - New clear_field() tool to dynamically clear issue fields based on schema type
  - Automatic update check on server startup (_check_for_updates())
  - One-time update warning emission via MCP context
  - Warning integration into all tool calls

  6. New Test File (tests/test_update_check.py)
  - 131 lines of tests covering the update check functionality
  - Tests for: warning detection, no-warning when up-to-date, git failures, warning emission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to clear Jira issue fields that adapts to field types.
  * Introduced one-time update warnings that notify when the running codebase is behind.
  * Enhanced build helpers: added a test alias and an install-commands command; updated help output.

* **Tests**
  * Added unit tests covering update-check behavior and one-time warning emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->