### PR TITLE
Support issue custom fields

### DIFF
--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -59,6 +59,21 @@ def _validate_git_commit_sha(sha: str) -> None:
         raise ValueError(f"Git commit SHA must be either 40 characters (SHA-1) or 64 characters (SHA-256), got {len(sha)} characters: {sha}")
 
 
+def _merge_custom_fields(
+    named_fields: Dict[str, Any],
+    custom_fields: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Merge caller-supplied custom_fields with named-parameter fields.
+
+    Named-parameter fields take precedence when both dicts contain the same key.
+    """
+    if not custom_fields:
+        return named_fields
+    merged = dict(custom_fields)
+    merged.update(named_fields)
+    return merged
+
+
 # Pydantic models for structured responses
 class SubtaskResponse(BaseModel):
     key: str
@@ -323,6 +338,7 @@ class JiraMCPServer:
             git_pull_requests: Optional[str] = None,
             parent: Optional[str] = None,
             epic_name: Optional[str] = None,
+            custom_fields: Optional[Dict[str, Any]] = None,
             ctx: Optional[Context] = None
         ) -> IssueResponse:
             """Create a new Jira issue.
@@ -360,6 +376,12 @@ class JiraMCPServer:
                 git_pull_requests: Git pull requests, comma separated list of pull requests URLs
                 parent: Parent issue key for sub-tasks (e.g., 'PROJ-123')
                 epic_name: Epic Name (required for Epic issue type)
+                custom_fields: Dictionary of arbitrary Jira field IDs to values. Use the
+                    debug_issue_fields tool to discover available field IDs on existing issues.
+                    Useful for instance-specific fields such as Parent Link or Epic Link.
+                    Example: {"customfield_12313140": "PROJ-100"}.
+                    Named parameters (e.g. story_points) take precedence over
+                    custom_fields when both set the same underlying field.
                 ctx: MCP context for progress reporting
             """
             # Validate required fields
@@ -420,7 +442,9 @@ class JiraMCPServer:
                 fields['parent'] = {'key': parent}  # Parent issue for sub-tasks
             if epic_name:
                 fields['customfield_12311141'] = epic_name  # Epic Name custom field
-            
+
+            fields = _merge_custom_fields(fields, custom_fields)
+
             try:
                 issue = await self.client.create_issue(
                     project_key, summary, description, issue_type, **fields
@@ -465,6 +489,7 @@ class JiraMCPServer:
             story_points: Optional[float] = None,
             git_commit: Optional[str] = None,
             git_pull_requests: Optional[str] = None,
+            custom_fields: Optional[Dict[str, Any]] = None,
             ctx: Optional[Context] = None
         ) -> IssueResponse:
             """Update an existing Jira issue.
@@ -495,6 +520,12 @@ class JiraMCPServer:
                 story_points: Story points value
                 git_commit: Git commit hash or reference
                 git_pull_requests: Git pull requests, comma separated list of pull requests URLs
+                custom_fields: Dictionary of arbitrary Jira field IDs to values. Use the
+                    debug_issue_fields tool to discover available field IDs on existing issues.
+                    Useful for instance-specific fields such as Parent Link or Epic Link.
+                    Example: {"customfield_12313140": "PROJ-100"}.
+                    Named parameters (e.g. story_points) take precedence over
+                    custom_fields when both set the same underlying field.
                 ctx: MCP context for progress reporting
             """
             if ctx:
@@ -542,6 +573,8 @@ class JiraMCPServer:
                 fields['customfield_12317372'] = git_commit  # Git Commit custom field
             if git_pull_requests:
                 fields['customfield_12310220'] = git_pull_requests  # Git Pull Requests custom field
+
+            fields = _merge_custom_fields(fields, custom_fields)
 
             if not fields:
                 raise ValueError("At least one field must be provided to update an issue")

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -1,0 +1,80 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for custom field support in create_issue and update_issue."""
+
+import pytest
+from jira_mcp_server.server import _merge_custom_fields
+
+
+class TestMergeCustomFields:
+    """Test the _merge_custom_fields helper."""
+
+    def test_none_custom_fields_returns_named_unchanged(self):
+        named = {"priority": {"name": "High"}, "labels": ["bug"]}
+        result = _merge_custom_fields(named, None)
+        assert result == named
+        assert result is named
+
+    def test_empty_custom_fields_returns_named_unchanged(self):
+        named = {"priority": {"name": "High"}}
+        result = _merge_custom_fields(named, {})
+        assert result == named
+        assert result is named
+
+    def test_custom_fields_merged_into_result(self):
+        named = {"priority": {"name": "High"}}
+        custom = {"customfield_12313140": "PROJ-100"}
+        result = _merge_custom_fields(named, custom)
+        assert result == {
+            "priority": {"name": "High"},
+            "customfield_12313140": "PROJ-100",
+        }
+
+    def test_named_fields_take_precedence_over_custom_fields(self):
+        named = {"customfield_12310243": 5.0}
+        custom = {"customfield_12310243": 10.0}
+        result = _merge_custom_fields(named, custom)
+        assert result["customfield_12310243"] == 5.0
+
+    def test_empty_named_with_custom_fields(self):
+        custom = {"customfield_12311140": "EPIC-1"}
+        result = _merge_custom_fields({}, custom)
+        assert result == {"customfield_12311140": "EPIC-1"}
+
+    def test_multiple_custom_fields(self):
+        named = {"summary": "test"}
+        custom = {
+            "customfield_12313140": "FEAT-1",
+            "customfield_12311140": "EPIC-2",
+            "customfield_99999999": {"id": "42"},
+        }
+        result = _merge_custom_fields(named, custom)
+        assert result == {
+            "summary": "test",
+            "customfield_12313140": "FEAT-1",
+            "customfield_12311140": "EPIC-2",
+            "customfield_99999999": {"id": "42"},
+        }
+
+    def test_does_not_mutate_inputs(self):
+        named = {"priority": {"name": "High"}}
+        custom = {"customfield_12313140": "PROJ-1"}
+        named_copy = dict(named)
+        custom_copy = dict(custom)
+
+        _merge_custom_fields(named, custom)
+
+        assert named == named_copy
+        assert custom == custom_copy


### PR DESCRIPTION
Some fields (e.g. epic link or parent link) can be custom fields. Agents can discover them with debug_issue_fields, but cannot currently write them. This gives them a path to do so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Jira fields when creating and updating issues. Users can now specify additional custom fields alongside standard fields. Standard fields take precedence in case of conflicts.

* **Tests**
  * Added comprehensive test coverage for custom field functionality, validating merging behavior, field precedence rules, and input immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->