### PR TITLE
Update custom field IDs and work type IDs for Jira Cloud migration, a…

### DIFF
--- a/.claude/agents/jira-specialist.md
+++ b/.claude/agents/jira-specialist.md
@@ -16,7 +16,7 @@ You are a Jira expert responsible for finding and analyzing Epics and Stories, c
 - **Project:** ACM
 - **Assignee/Reporter:** jpacker@redhat.com
 - **Fix Version:** ACM 2.15.0
-- **Work Type IDs:** None = -1, Wellness = 46650, Sustainability = 48051, Support = 46651, Quality = 46653, Security = 46652, Portfolio = 46654
+- **Work Type IDs:** None = -1, Wellness = 10604, BU Features = 10605, Sustainability = 10606, Support = 10607, Quality = 10608, Security = 10609, Portfolio = 10610
 
 ## Issue Types
 - **Epic** - Large features/initiatives

--- a/.claude/commands/jira-create.md
+++ b/.claude/commands/jira-create.md
@@ -48,12 +48,13 @@ Use `AskUserQuestion` to collect the remaining fields. Group questions logically
 
 **Work Type** (submit as ID number):
 - None = -1
-- Associate Wellness & Development = 46650
-- Future Sustainability = 48051
-- Incident & Support = 46651
-- Quality / Stability / Reliability = 46653
-- Security & Compliance = 46652
-- Product / Portfolio Work = 46654
+- Associate Wellness & Development = 10604
+- BU Features = 10605
+- Future Sustainability = 10606
+- Incidents & Support = 10607
+- Quality / Stability / Reliability = 10608
+- Security & Compliance = 10609
+- Product / Portfolio Work = 10610
 
 **Original Estimate** (e.g., '2h', '1d', '30m')
 

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ JIRA_SERVER_URL=https://your-company.atlassian.net
 # For Atlassian Cloud, use an API token: https://id.atlassian.com/manage-profile/security/api-tokens
 JIRA_ACCESS_TOKEN=your-api-token
 
+# Required for Jira Cloud: Your Atlassian account email address
+JIRA_EMAIL=your-email@company.com
+
 # Optional: SSL verification (default: true)
 JIRA_VERIFY_SSL=true
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A Model Context Protocol (MCP) server that provides seamless integration with Jira instances. This server enables AI applications to interact with Jira issues, projects, and workflows through a standardized interface.
 
+## Jira Cloud Migration
+
+The server has been updated to work with the new Jira Cloud instance. To migrate:
+
+1. **Pull the latest changes**
+```bash
+cd /path/to/jira-mcp-server && git pull
+```
+
+2. **Update your `.env` file**
+```env
+JIRA_SERVER_URL=https://redhat.atlassian.net
+JIRA_ACCESS_TOKEN=<your-api-token>
+JIRA_EMAIL=<your-email>@redhat.com
+```
+
+3. **Get your API token** — Go to https://id.atlassian.com/manage-profile/security/api-tokens and click "Create API token"
+
+4. **Reconnect** — In Claude Code run `/mcp` to reconnect, or restart your client (Cursor, Gemini CLI, etc.)
+
+All custom field IDs and work type IDs have been updated in the code. No other changes needed.
+
 ## Table of Contents
 
 1. [Features](#features)
@@ -65,6 +87,7 @@ cp .env.example .env
 ```env
 JIRA_SERVER_URL=https://your-company.atlassian.net
 JIRA_ACCESS_TOKEN=your-personal-access-token
+JIRA_EMAIL=your-email@company.com
 JIRA_VERIFY_SSL=true
 JIRA_TIMEOUT=30
 JIRA_MAX_RESULTS=100
@@ -85,9 +108,11 @@ For Jira Cloud (Atlassian Cloud), you'll need to:
 1. Create a personal access token:
    - Go to https://id.atlassian.com/manage-profile/security/api-tokens
    - Click "Create API token"
-   - Use the access token as the JIRA_ACCESS_TOKEN
+   - Use the access token as the `JIRA_ACCESS_TOKEN`
 
-2. Use your full Atlassian domain (e.g., `https://yourcompany.atlassian.net`)
+2. Set `JIRA_EMAIL` to the email address associated with your Atlassian account (required for Cloud authentication)
+
+3. Use your full Atlassian domain (e.g., `https://yourcompany.atlassian.net`)
 
 ### Jira Server/Data Center Setup
 
@@ -648,6 +673,7 @@ jira_mcp_server/
 
 **Solutions**:
 - Verify Jira credentials in the `.env` file
+- For Jira Cloud: ensure `JIRA_EMAIL` is set to your Atlassian account email
 - Check if the Jira server URL is correct
 - Ensure the personal access token is valid
 - Test credentials with a simple Jira API call
@@ -707,6 +733,7 @@ You can override any configuration by setting environment variables:
 
 ```bash
 export JIRA_SERVER_URL="https://custom-jira.company.com"
+export JIRA_EMAIL="your-email@company.com"
 export JIRA_TIMEOUT="60"
 export JIRA_MAX_RESULTS="200"
 export JIRA_TEAMS='{"frontend": ["alice", "bob"], "backend": ["charlie"]}'
@@ -866,7 +893,8 @@ To connect to multiple Jira instances, create separate MCP server configurations
       "cwd": "/home/user/workspace_git/jira-mcp-server",
       "env": {
         "JIRA_SERVER_URL": "https://prod.atlassian.net",
-        "JIRA_ACCESS_TOKEN": "prod-token"
+        "JIRA_ACCESS_TOKEN": "prod-token",
+        "JIRA_EMAIL": "you@company.com"
       }
     },
     "jira-staging": {
@@ -874,8 +902,9 @@ To connect to multiple Jira instances, create separate MCP server configurations
       "args": ["-m", "jira_mcp_server.main"],
       "cwd": "/home/user/workspace_git/jira-mcp-server",
       "env": {
-        "JIRA_SERVER_URL": "https://staging.atlassian.net",
-        "JIRA_ACCESS_TOKEN": "staging-token"
+        "JIRA_SERVER_URL": "https://company.atlassian.net",
+        "JIRA_ACCESS_TOKEN": "cloud-token",
+        "JIRA_EMAIL": "you@company.com"
       }
     }
   }

--- a/doc/COMPONENT_ALIASES.md
+++ b/doc/COMPONENT_ALIASES.md
@@ -59,7 +59,7 @@ create_issue(
     description="The login button is not responding to clicks",
     issue_type="Bug",
     priority="High",
-    work_type="46654",
+    work_type="10610",
     due_date="2025-12-31",
     components=["ui", "be"]  # Will resolve to ["User Interface", "Backend Services"]
 )
@@ -72,7 +72,7 @@ create_issue(
 update_issue(
     issue_key="ACM-123",
     priority="High",
-    work_type="46654",
+    work_type="10610",
     due_date="2025-12-31",
     components=["ui", "db"]  # Mix of aliases
 )
@@ -88,7 +88,7 @@ create_issue(
     description="Optimize database queries for better performance",
     issue_type="Task",
     priority="Medium",
-    work_type="46654",
+    work_type="10610",
     due_date="2025-12-31",
     components=["db", "Performance Testing"]  # Alias + actual name
 )
@@ -281,7 +281,7 @@ create_issue(
     description="Addon fails to deploy on new clusters",
     issue_type="Bug",
     priority="High",
-    work_type="46651",  # Incident & Support
+    work_type="10607",  # Incident & Support
     due_date="2025-11-30",
     components=["addon", "hcp"]  # Resolves to actual component names
 )
@@ -304,7 +304,7 @@ create_issue(
     description="Response times increased by 50% in production",
     issue_type="Bug",
     priority="Critical",
-    work_type="46651",
+    work_type="10607",
     due_date="2025-11-20",
     components=["fe", "api", "db"]  # Three components with short aliases
 )

--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -723,16 +723,16 @@ class JiraClient:
             ],
             'url': f"{self.config.server_url}/browse/{issue.key}",
             'fix_versions': [version.name for version in getattr(issue.fields, 'fixVersions', [])],
-            'target_version': [v.name for v in getattr(issue.fields, 'customfield_12319940', []) or []],  # Target Version custom field
-            'work_type': self._extract_custom_field_value(getattr(issue.fields, 'customfield_12320040', None)),  # Work type custom field
+            'target_version': [v.name for v in getattr(issue.fields, 'customfield_10855', []) or []],  # Target Version custom field
+            'work_type': self._extract_custom_field_value(getattr(issue.fields, 'customfield_10464', None)),  # Activity Type (formerly Work Type)
             'security_level': getattr(issue.fields.security, 'name', None) if getattr(issue.fields, 'security', None) else None,
             'due_date': getattr(issue.fields, 'duedate', None),
-            'target_start': getattr(issue.fields, 'customfield_12313941', None),  # Target Start custom field
-            'target_end': getattr(issue.fields, 'customfield_12313942', None),  # Target End custom field
+            'target_start': getattr(issue.fields, 'customfield_10022', None),  # Target Start custom field
+            'target_end': getattr(issue.fields, 'customfield_10023', None),  # Target End custom field
             'original_estimate': self._seconds_to_time_string(getattr(issue.fields, 'timeoriginalestimate', None)),
-            'story_points': getattr(issue.fields, 'customfield_12310243', None),  # Story points custom field
-            'git_commit': self._extract_custom_field_value(getattr(issue.fields, 'customfield_12317372', None)),  # Git Commit custom field
-            'git_pull_requests': self._extract_git_pull_requests(getattr(issue.fields, 'customfield_12310220', None)),  # Git Pull Requests custom field
+            'story_points': getattr(issue.fields, 'customfield_10028', None),  # Story points custom field
+            'git_commit': self._extract_custom_field_value(getattr(issue.fields, 'customfield_10583', None)),  # Git Commit custom field
+            'git_pull_requests': self._extract_git_pull_requests(getattr(issue.fields, 'customfield_10875', None)),  # Git Pull Requests custom field
             'subtasks': [
                 {
                     'key': subtask.key,
@@ -747,8 +747,8 @@ class JiraClient:
                 'summary': issue.fields.parent.fields.summary,
                 'issue_type': issue.fields.parent.fields.issuetype.name
             } if getattr(issue.fields, 'parent', None) else None,
-            'parent_link': getattr(issue.fields, 'customfield_12313140', None),  # Parent Link custom field
-            'epic_link': getattr(issue.fields, 'customfield_12311140', None),  # Epic Link custom field
+            'parent_link': getattr(issue.fields, 'customfield_10014', None),  # Parent Link custom field
+            'epic_link': getattr(issue.fields, 'customfield_10014', None),  # Epic Link custom field
         }
 
         return result

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -347,12 +347,13 @@ class JiraMCPServer:
                 target_version: List of target version names (set when issue is created)
                 work_type: Work type for the issue (STRONGLY RECOMMENDED). Available options:
                     - **None** = -1
-                    - **Associate Wellness & Development** = 46650
-                    - **Future Sustainability** = 48051
-                    - **Incident & Support** = 46651
-                    - **Quality / Stability / Reliability** = 46653
-                    - **Security & Compliance** = 46652
-                    - **Product / Portfolio Work** = 46654
+                    - **Associate Wellness & Development** = 10604
+                    - **BU Features** = 10605
+                    - **Future Sustainability** = 10606
+                    - **Incidents & Support** = 10607
+                    - **Quality / Stability / Reliability** = 10608
+                    - **Security & Compliance** = 10609
+                    - **Product / Portfolio Work** = 10610
                 security_level: Security level name
                 due_date: Due date in YYYY-MM-DD format
                 target_start: Target start date in YYYY-MM-DD format
@@ -400,17 +401,17 @@ class JiraMCPServer:
                 fields['fixVersions'] = [{'name': version} for version in fix_versions]
             if target_version:
                 # Target versions need to be converted to objects with 'name' property
-                fields['customfield_12319940'] = [{'name': version} for version in target_version]
+                fields['customfield_10855'] = [{'name': version} for version in target_version]
             if work_type:
-                fields['customfield_12320040'] = {'id': str(work_type)}  # Work type custom field
+                fields['customfield_10464'] = {'id': str(work_type)}  # Activity Type (formerly Work Type)
             if security_level:
                 fields['security'] = {'name': security_level}
             if due_date:
                 fields['duedate'] = due_date
             if target_start:
-                fields['customfield_12313941'] = target_start  # Target Start custom field
+                fields['customfield_10022'] = target_start  # Target Start custom field
             if target_end:
-                fields['customfield_12313942'] = target_end  # Target End custom field
+                fields['customfield_10023'] = target_end  # Target End custom field
             if components:
                 # Resolve component aliases to actual component names
                 resolved_components = self.config.resolve_component_names(components)
@@ -419,20 +420,20 @@ class JiraMCPServer:
             if original_estimate:
                 fields['timetracking'] = {'originalEstimate': original_estimate}
             if story_points is not None:
-                fields['customfield_12310243'] = story_points  # Story points custom field
+                fields['customfield_10028'] = story_points  # Story points custom field
             if git_commit:
                 _validate_git_commit_sha(git_commit)
-                fields['customfield_12317372'] = git_commit  # Git Commit custom field
+                fields['customfield_10583'] = git_commit  # Git Commit custom field
             if git_pull_requests:
-                fields['customfield_12310220'] = git_pull_requests  # Git Pull Requests custom field
+                fields['customfield_10875'] = git_pull_requests  # Git Pull Requests custom field
             if parent:
                 fields['parent'] = {'key': parent}  # Parent issue for sub-tasks
             if epic_name:
-                fields['customfield_12311141'] = epic_name  # Epic Name custom field
+                fields['customfield_10011'] = epic_name  # Epic Name custom field
             if parent_link:
-                fields['customfield_12313140'] = parent_link  # Parent Link custom field
+                fields['customfield_10014'] = parent_link  # Parent Link custom field
             if epic_link:
-                fields['customfield_12311140'] = epic_link  # Epic Link custom field
+                fields['customfield_10014'] = epic_link  # Epic Link custom field
 
             try:
                 issue = await self.client.create_issue(
@@ -495,12 +496,13 @@ class JiraMCPServer:
                 target_version: List of target version names (set when issue is created)
                 work_type: Work type for the issue (STRONGLY RECOMMENDED). Available options:
                     - **None** = -1
-                    - **Associate Wellness & Development** = 46650
-                    - **Future Sustainability** = 48051
-                    - **Incident & Support** = 46651
-                    - **Quality / Stability / Reliability** = 46653
-                    - **Security & Compliance** = 46652
-                    - **Product / Portfolio Work** = 46654
+                    - **Associate Wellness & Development** = 10604
+                    - **BU Features** = 10605
+                    - **Future Sustainability** = 10606
+                    - **Incidents & Support** = 10607
+                    - **Quality / Stability / Reliability** = 10608
+                    - **Security & Compliance** = 10609
+                    - **Product / Portfolio Work** = 10610
                 security_level: Security level name
                 due_date: Due date in YYYY-MM-DD format
                 target_start: Target start date in YYYY-MM-DD format
@@ -537,17 +539,17 @@ class JiraMCPServer:
                 fields['fixVersions'] = [{'name': version} for version in fix_versions]
             if target_version:
                 # Target versions need to be converted to objects with 'name' property
-                fields['customfield_12319940'] = [{'name': version} for version in target_version]
+                fields['customfield_10855'] = [{'name': version} for version in target_version]
             if work_type:
-                fields['customfield_12320040'] = {'id': str(work_type)}  # Work type custom field
+                fields['customfield_10464'] = {'id': str(work_type)}  # Activity Type (formerly Work Type)
             if security_level:
                 fields['security'] = {'name': security_level}
             if due_date:
                 fields['duedate'] = due_date
             if target_start:
-                fields['customfield_12313941'] = target_start  # Target Start custom field
+                fields['customfield_10022'] = target_start  # Target Start custom field
             if target_end:
-                fields['customfield_12313942'] = target_end  # Target End custom field
+                fields['customfield_10023'] = target_end  # Target End custom field
             if components:
                 # Resolve component aliases to actual component names
                 resolved_components = self.config.resolve_component_names(components)
@@ -556,16 +558,16 @@ class JiraMCPServer:
             if original_estimate:
                 fields['timetracking'] = {'originalEstimate': original_estimate}
             if story_points is not None:
-                fields['customfield_12310243'] = story_points  # Story points custom field
+                fields['customfield_10028'] = story_points  # Story points custom field
             if git_commit:
                 _validate_git_commit_sha(git_commit)
-                fields['customfield_12317372'] = git_commit  # Git Commit custom field
+                fields['customfield_10583'] = git_commit  # Git Commit custom field
             if git_pull_requests:
-                fields['customfield_12310220'] = git_pull_requests  # Git Pull Requests custom field
+                fields['customfield_10875'] = git_pull_requests  # Git Pull Requests custom field
             if parent_link:
-                fields['customfield_12313140'] = parent_link  # Parent Link custom field
+                fields['customfield_10014'] = parent_link  # Parent Link custom field
             if epic_link:
-                fields['customfield_12311140'] = epic_link  # Epic Link custom field
+                fields['customfield_10014'] = epic_link  # Epic Link custom field
 
             if not fields:
                 raise ValueError("At least one field must be provided to update an issue")
@@ -594,7 +596,7 @@ class JiraMCPServer:
             Args:
                 issue_key: Jira issue key (e.g., 'PROJ-123')
                 field_name: The Jira field ID to clear (e.g., 'fixVersions',
-                    'customfield_12319940', 'duedate', 'labels', 'components',
+                    'customfield_10855', 'duedate', 'labels', 'components',
                     'assignee', 'priority', 'security', 'timetracking').
                     Use the debug_issue_fields tool to discover available field IDs.
                 ctx: MCP context for progress reporting


### PR DESCRIPTION
…dd JIRA_EMAIL docs

Remapped all custom field IDs from old Jira Server format (12xxxxx) to new Jira Cloud format (10xxx) in server.py and client.py:

- Target Version: customfield_12319940 to customfield_10855
- Work Type: customfield_12320040 to customfield_10464
- Target Start: customfield_12313941 to customfield_10022
- Target End: customfield_12313942 to customfield_10023
- Story Points: customfield_12310243 to customfield_10028
- Git Commit: customfield_12317372 to customfield_10583
- Git Pull Requests: customfield_12310220 to customfield_10875
- Epic Name: customfield_12311141 to customfield_10011
- Epic Link: customfield_12311140 to customfield_10014

Updated work type (Activity Type) option IDs across all files:
- CLAUDE.md, server.py, jira-create.md, jira-specialist.md, COMPONENT_ALIASES.md

Added JIRA_EMAIL as a required config variable for Jira Cloud in README.md and .env.example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added JIRA_EMAIL environment variable configuration requirement for Jira Cloud authentication setup.
* Updated work type options (now labeled Activity Type) with new available selections.
* Updated Jira field mappings for issue creation, updates, and field clearing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->