### PR TITLE
Fix Jira Cloud compatibility: assignee, user search, and parent hierarchy

### DIFF
--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -17,12 +17,15 @@
 """Jira client wrapper for MCP server."""
 
 import asyncio
+import logging
 from typing import List, Dict, Any, Optional
 from jira import JIRA
 from jira.exceptions import JIRAError
 from asyncio_throttle import Throttler
 
 from .config import JiraConfig
+
+logger = logging.getLogger(__name__)
 
 
 class JiraClient:
@@ -35,31 +38,18 @@ class JiraClient:
         self.throttler = Throttler(rate_limit=10, period=1.0)  # 10 requests per second
     
     async def connect(self) -> None:
-        """Connect to Jira server using appropriate authentication method.
-
-        For Jira Cloud (atlassian.net): Uses basic auth with email and API token
-        For self-hosted Jira: Uses personal access token authentication
-        """
+        """Connect to Jira Cloud using basic auth with email and API token."""
         try:
             options = {
                 'verify': self.config.verify_ssl,
                 'timeout': self.config.timeout
             }
 
-            if self.config.is_cloud():
-                # Jira Cloud requires basic auth with email and API token
-                self._jira = JIRA(
-                    server=self.config.server_url,
-                    basic_auth=(self.config.email, self.config.access_token),
-                    options=options
-                )
-            else:
-                # Self-hosted Jira uses personal access token
-                self._jira = JIRA(
-                    server=self.config.server_url,
-                    token_auth=self.config.access_token,
-                    options=options
-                )
+            self._jira = JIRA(
+                server=self.config.server_url,
+                basic_auth=(self.config.email, self.config.access_token),
+                options=options
+            )
 
             # Test connection
             await self._async_call(lambda: self._jira.myself())
@@ -374,35 +364,81 @@ class JiraClient:
             raise ValueError(f"Failed to get issue link types: {e}")
 
     async def search_users(self, query: str, max_results: int = 50) -> List[Dict[str, Any]]:
-        """Search for Jira users by name or email.
+        """Search for Jira Cloud users by name or email.
+
+        Uses the GDPR-compliant ``query`` parameter via a direct REST call
+        (the jira-python library sends ``?username=...`` which Jira Cloud
+        rejects in GDPR strict mode).
 
         Args:
-            query: Search query (name, email, or username - supports fuzzy matching)
+            query: Search query (display name or email - supports fuzzy matching)
             max_results: Maximum number of results to return (default: 50)
 
         Returns:
-            List of user dictionaries with key, name, displayName, and emailAddress
+            List of user dictionaries with account_id, name, display_name,
+            email_address, and active status.
         """
         if not self._jira:
             raise RuntimeError("Not connected to Jira")
 
-        try:
-            users = await self._async_call(
-                lambda: self._jira.search_users(query, maxResults=max_results)
+        url = (
+            f"{self._jira._options['server']}/rest/api/2/user/search"
+            f"?query={query}&maxResults={max_results}"
+        )
+        response = await self._async_call(lambda: self._jira._session.get(url))
+        if not response.ok:
+            raise ValueError(
+                f"User search failed (HTTP {response.status_code}): "
+                f"{response.text}"
+            )
+        return [
+            {
+                'account_id': u.get('accountId'),
+                'name': u.get('name'),
+                'display_name': u.get('displayName', ''),
+                'email_address': u.get('emailAddress'),
+                'active': u.get('active', True),
+            }
+            for u in response.json()
+        ]
+
+    async def resolve_assignee(self, value: str) -> Dict[str, str]:
+        """Resolve an assignee value to an ``{"accountId": "..."}`` payload.
+
+        The *value* may be a display name, an email address, or an accountId.
+        When a display name or email is given, a user search is performed to
+        look up the accountId.
+
+        Args:
+            value: Display name, email, or accountId of the target assignee.
+
+        Raises:
+            ValueError: If the user cannot be resolved unambiguously.
+        """
+        if ':' in value:
+            return {'accountId': value}
+
+        users = await self.search_users(value, max_results=50)
+        if not users:
+            raise ValueError(
+                f"No Jira user found matching '{value}'. "
+                "Provide an accountId, exact display name, or email address."
             )
 
-            return [
-                {
-                    'account_id': getattr(user, 'accountId', None),
-                    'name': getattr(user, 'name', None),
-                    'display_name': getattr(user, 'displayName', ''),
-                    'email_address': getattr(user, 'emailAddress', None),
-                    'active': getattr(user, 'active', True)
-                }
-                for user in users
-            ]
-        except JIRAError as e:
-            raise ValueError(f"Failed to search users: {e}")
+        exact = [
+            u for u in users
+            if (u.get('display_name') or '').lower() == value.lower()
+            or (u.get('email_address') or '').lower() == value.lower()
+        ]
+        match = exact[0] if exact else users[0]
+
+        account_id = match.get('account_id')
+        if not account_id:
+            raise ValueError(
+                f"User '{value}' was found but has no accountId. "
+                "This may indicate a service account or deactivated user."
+            )
+        return {'accountId': account_id}
 
     async def get_raw_issue_fields(self, issue_key: str) -> Dict[str, Any]:
         """Get all raw fields from a Jira issue for debugging purposes."""
@@ -747,8 +783,6 @@ class JiraClient:
                 'summary': issue.fields.parent.fields.summary,
                 'issue_type': issue.fields.parent.fields.issuetype.name
             } if getattr(issue.fields, 'parent', None) else None,
-            'parent_link': getattr(issue.fields, 'customfield_10014', None),  # Parent Link custom field
-            'epic_link': getattr(issue.fields, 'customfield_10014', None),  # Epic Link custom field
         }
 
         return result

--- a/jira_mcp_server/config.py
+++ b/jira_mcp_server/config.py
@@ -74,18 +74,14 @@ class JiraConfig(BaseModel):
             component_aliases=component_aliases,
         )
 
-    def is_cloud(self) -> bool:
-        """Check if this is a Jira Cloud instance."""
-        return "atlassian.net" in self.server_url.lower()
-
     def validate_required_fields(self) -> None:
         """Validate that required fields are present."""
         if not self.server_url:
             raise ValueError("JIRA_SERVER_URL is required")
         if not self.access_token:
             raise ValueError("JIRA_ACCESS_TOKEN is required")
-        if self.is_cloud() and not self.email:
-            raise ValueError("JIRA_EMAIL is required for Jira Cloud instances")
+        if not self.email:
+            raise ValueError("JIRA_EMAIL is required")
     
     def get_team_members(self, team_name: str) -> List[str]:
         """Get members of a team by name.

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -101,8 +101,6 @@ class IssueResponse(BaseModel):
     git_pull_requests: Optional[str]
     subtasks: List[SubtaskResponse]
     parent: Optional[ParentResponse]
-    parent_link: Optional[str] = None
-    epic_link: Optional[str] = None
 
 class ProjectResponse(BaseModel):
     key: str
@@ -325,8 +323,6 @@ class JiraMCPServer:
             git_pull_requests: Optional[str] = None,
             parent: Optional[str] = None,
             epic_name: Optional[str] = None,
-            parent_link: Optional[str] = None,
-            epic_link: Optional[str] = None,
             ctx: Optional[Context] = None
         ) -> IssueResponse:
             """Create a new Jira issue.
@@ -363,13 +359,10 @@ class JiraMCPServer:
                 story_points: Story points value. RECOMMENDED for better sprint planning.
                 git_commit: Git commit hash or reference
                 git_pull_requests: Git pull requests, comma separated list of pull requests URLs
-                parent: Parent issue key for sub-tasks (e.g., 'PROJ-123')
+                parent: Parent issue key for hierarchy (e.g., 'PROJ-123'). Works
+                    for all hierarchy levels: Story to Epic, Epic to Feature,
+                    sub-tasks, etc.
                 epic_name: Epic Name (required for Epic issue type)
-                parent_link: Parent link issue key for hierarchy (e.g., linking an Epic
-                    to its parent Feature). Use instead of 'parent' for non-sub-task
-                    relationships (e.g., 'PROJ-100').
-                epic_link: Epic link issue key for linking a Story to its parent Epic
-                    (e.g., 'PROJ-200').
                 ctx: MCP context for progress reporting
             """
             # Validate required fields
@@ -392,7 +385,7 @@ class JiraMCPServer:
             if priority:
                 fields['priority'] = {'name': priority}
             if assignee:
-                fields['assignee'] = {'name': assignee}
+                fields['assignee'] = await self.client.resolve_assignee(assignee)
             if labels:
                 # Labels are passed as array of strings directly to Jira API
                 fields['labels'] = labels
@@ -427,13 +420,9 @@ class JiraMCPServer:
             if git_pull_requests:
                 fields['customfield_10875'] = git_pull_requests  # Git Pull Requests custom field
             if parent:
-                fields['parent'] = {'key': parent}  # Parent issue for sub-tasks
+                fields['parent'] = {'key': parent}
             if epic_name:
-                fields['customfield_10011'] = epic_name  # Epic Name custom field
-            if parent_link:
-                fields['customfield_10014'] = parent_link  # Parent Link custom field
-            if epic_link:
-                fields['customfield_10014'] = epic_link  # Epic Link custom field
+                fields['customfield_10011'] = epic_name
 
             try:
                 issue = await self.client.create_issue(
@@ -479,8 +468,7 @@ class JiraMCPServer:
             story_points: Optional[float] = None,
             git_commit: Optional[str] = None,
             git_pull_requests: Optional[str] = None,
-            parent_link: Optional[str] = None,
-            epic_link: Optional[str] = None,
+            parent: Optional[str] = None,
             ctx: Optional[Context] = None
         ) -> IssueResponse:
             """Update an existing Jira issue.
@@ -512,11 +500,9 @@ class JiraMCPServer:
                 story_points: Story points value
                 git_commit: Git commit hash or reference
                 git_pull_requests: Git pull requests, comma separated list of pull requests URLs
-                parent_link: Parent link issue key for hierarchy (e.g., linking an Epic
-                    to its parent Feature). Use instead of 'parent' for non-sub-task
-                    relationships (e.g., 'PROJ-100').
-                epic_link: Epic link issue key for linking a Story to its parent Epic
-                    (e.g., 'PROJ-200').
+                parent: Parent issue key for hierarchy (e.g., 'PROJ-123'). Works
+                    for all hierarchy levels: Story to Epic, Epic to Feature,
+                    sub-tasks, etc.
                 ctx: MCP context for progress reporting
             """
             if ctx:
@@ -530,7 +516,7 @@ class JiraMCPServer:
             if priority:
                 fields['priority'] = {'name': priority}
             if assignee:
-                fields['assignee'] = {'name': assignee}
+                fields['assignee'] = await self.client.resolve_assignee(assignee)
             if labels:
                 # Labels are passed as array of strings directly to Jira API
                 fields['labels'] = labels
@@ -564,10 +550,8 @@ class JiraMCPServer:
                 fields['customfield_10583'] = git_commit  # Git Commit custom field
             if git_pull_requests:
                 fields['customfield_10875'] = git_pull_requests  # Git Pull Requests custom field
-            if parent_link:
-                fields['customfield_10014'] = parent_link  # Parent Link custom field
-            if epic_link:
-                fields['customfield_10014'] = epic_link  # Epic Link custom field
+            if parent:
+                fields['parent'] = {'key': parent}
 
             if not fields:
                 raise ValueError("At least one field must be provided to update an issue")
@@ -897,8 +881,9 @@ class JiraMCPServer:
 
             Returns:
                 List of matching users with their account_id, name, display_name,
-                email_address, and active status. Use the 'name' field for assignee
-                operations in self-hosted Jira, or 'account_id' for Jira Cloud.
+                email_address, and active status.  When using create_issue or
+                update_issue, the assignee parameter handles accountId resolution
+                automatically.
             """
             if ctx:
                 await ctx.info(f"Searching for users matching: {query}")

--- a/tests/test_cloud_compat.py
+++ b/tests/test_cloud_compat.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Jira Cloud compatibility: assignee resolution and
+GDPR-compliant user search."""
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from jira_mcp_server.client import JiraClient
+from jira_mcp_server.config import JiraConfig
+
+
+# ---------------------------------------------------------------------------
+# Reusable fakes
+# ---------------------------------------------------------------------------
+
+class FakeResponse:
+    """Minimal stand-in for a ``requests.Response``."""
+
+    def __init__(self, data: Any, status_code: int = 200):
+        self._data = data
+        self.status_code = status_code
+        self.text = json.dumps(data) if not isinstance(data, str) else data
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self) -> Any:
+        return self._data
+
+
+class FakeSession:
+    """Fake HTTP session that records ``get`` calls and returns canned data."""
+
+    def __init__(self) -> None:
+        self.get_calls: List[str] = []
+        self._responses: Dict[str, FakeResponse] = {}
+
+    def register(self, url_substring: str, response: FakeResponse) -> None:
+        self._responses[url_substring] = response
+
+    def get(self, url: str) -> FakeResponse:
+        self.get_calls.append(url)
+        for substring, response in self._responses.items():
+            if substring in url:
+                return response
+        return FakeResponse({"errorMessages": ["no canned response"]}, 404)
+
+
+class FakeJira:
+    """In-memory stand-in for ``jira.JIRA``.
+
+    Supports the subset of the API used by ``JiraClient``: the ``_options``
+    dict and the ``_session`` for raw REST calls.
+    """
+
+    def __init__(self, server_url: str = "https://redhat.atlassian.net"):
+        self._options: Dict[str, Any] = {"server": server_url}
+        self._session = FakeSession()
+
+
+def _make_config() -> JiraConfig:
+    return JiraConfig(
+        server_url="https://redhat.atlassian.net",
+        access_token="fake-token",
+        email="bot@redhat.com",
+    )
+
+
+def _make_client(fake_jira: FakeJira | None = None) -> JiraClient:
+    config = _make_config()
+    client = JiraClient(config)
+    client._jira = fake_jira or FakeJira()
+    return client
+
+
+# ---------------------------------------------------------------------------
+# search_users
+# ---------------------------------------------------------------------------
+
+class TestSearchUsers:
+    @pytest.fixture
+    def client(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([
+                {
+                    "accountId": "abc:123",
+                    "name": None,
+                    "displayName": "Alice A",
+                    "emailAddress": "alice@redhat.com",
+                    "active": True,
+                },
+            ]),
+        )
+        return _make_client(fake_jira=fake)
+
+    @pytest.mark.asyncio
+    async def test_uses_query_parameter(self, client):
+        results = await client.search_users("alice")
+        assert len(results) == 1
+        assert results[0]["account_id"] == "abc:123"
+        assert results[0]["display_name"] == "Alice A"
+
+        calls = client._jira._session.get_calls
+        assert len(calls) == 1
+        assert "query=alice" in calls[0]
+        assert "username" not in calls[0]
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse("GDPR strict mode error", 400),
+        )
+        client = _make_client(fake_jira=fake)
+
+        with pytest.raises(ValueError, match="User search failed"):
+            await client.search_users("bob")
+
+
+# ---------------------------------------------------------------------------
+# resolve_assignee
+# ---------------------------------------------------------------------------
+
+class TestResolveAssignee:
+    @pytest.mark.asyncio
+    async def test_account_id_passthrough(self):
+        client = _make_client()
+        result = await client.resolve_assignee("70121:0ea5df61-abcd-1234")
+        assert result == {"accountId": "70121:0ea5df61-abcd-1234"}
+
+    @pytest.mark.asyncio
+    async def test_resolves_display_name_via_search(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([
+                {
+                    "accountId": "abc:999",
+                    "name": None,
+                    "displayName": "Alice A",
+                    "emailAddress": "alice@redhat.com",
+                    "active": True,
+                },
+            ]),
+        )
+        client = _make_client(fake_jira=fake)
+
+        result = await client.resolve_assignee("Alice A")
+        assert result == {"accountId": "abc:999"}
+
+    @pytest.mark.asyncio
+    async def test_resolves_email_via_search(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([
+                {
+                    "accountId": "abc:888",
+                    "name": None,
+                    "displayName": "Bob B",
+                    "emailAddress": "bob@redhat.com",
+                    "active": True,
+                },
+            ]),
+        )
+        client = _make_client(fake_jira=fake)
+
+        result = await client.resolve_assignee("bob@redhat.com")
+        assert result == {"accountId": "abc:888"}
+
+    @pytest.mark.asyncio
+    async def test_no_match_raises(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([]),
+        )
+        client = _make_client(fake_jira=fake)
+
+        with pytest.raises(ValueError, match="No Jira user found"):
+            await client.resolve_assignee("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_prefers_exact_match(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([
+                {
+                    "accountId": "abc:wrong",
+                    "name": None,
+                    "displayName": "Alice Wonderland",
+                    "emailAddress": "alice.w@redhat.com",
+                    "active": True,
+                },
+                {
+                    "accountId": "abc:right",
+                    "name": None,
+                    "displayName": "Alice",
+                    "emailAddress": "alice@redhat.com",
+                    "active": True,
+                },
+            ]),
+        )
+        client = _make_client(fake_jira=fake)
+
+        result = await client.resolve_assignee("Alice")
+        assert result == {"accountId": "abc:right"}
+
+    @pytest.mark.asyncio
+    async def test_missing_account_id_raises(self):
+        fake = FakeJira()
+        fake._session.register(
+            "/rest/api/2/user/search",
+            FakeResponse([
+                {
+                    "accountId": None,
+                    "name": None,
+                    "displayName": "Ghost User",
+                    "emailAddress": "ghost@redhat.com",
+                    "active": False,
+                },
+            ]),
+        )
+        client = _make_client(fake_jira=fake)
+
+        with pytest.raises(ValueError, match="has no accountId"):
+            await client.resolve_assignee("Ghost User")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,6 +70,11 @@ def test_config_validation():
     with pytest.raises(ValueError, match="JIRA_ACCESS_TOKEN is required"):
         config.validate_required_fields()
     
-    # Should not raise when all fields are present
+    # Email is now always required
     config.access_token = "test"
+    with pytest.raises(ValueError, match="JIRA_EMAIL is required"):
+        config.validate_required_fields()
+
+    # Should not raise when all fields are present
+    config.email = "user@example.com"
     config.validate_required_fields()  # Should not raise

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -35,7 +35,7 @@ async def _run_jira_connection_check() -> None:
         print(f"   ✅ Configuration loaded successfully")
         print("   Server URL: [redacted]")
         print("   Email: [redacted]")
-        print(f"   Is Cloud: {config.is_cloud()}")
+        print(f"   Email configured: {bool(config.email)}")
         print()
     except Exception as e:
         print(f"   ❌ Failed to load configuration: {e}")


### PR DESCRIPTION
The Jira Cloud migration left several API incompatibilities:

- Assignee field used {"name": ...} which Cloud silently ignores;
  now resolves display names and emails to accountId via user search.
- User search sent ?username= which Cloud rejects in GDPR strict mode;
  now calls the REST endpoint directly with ?query= instead.
- Epic Link and Parent Link used separate custom fields that were
  mapped to the same field ID after migration; replaced
  with Cloud's native parent field which handles all hierarchy levels.

Drops Jira Server support: removes is_cloud() branching, Server auth
path, and legacy custom field discovery. The parent parameter on
create_issue and update_issue now works for Story→Epic, Epic→Feature,
and sub-task relationships uniformly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic assignee resolution that converts display names or email addresses to proper account identifiers.

* **Configuration Updates**
  * Email address is now required for all Jira instance configurations.

* **Changes**
  * Removed parent_link and epic_link from issue metadata output.
  * Improved logging and diagnostics for Jira integration operations.
  * Enhanced Jira Cloud compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->