### PR TITLE
fix(deps): update Python dependencies and resolve security vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 dependencies = [
     "fastmcp>=3.2.4",
     "jira>=3.10.5",
-    "pydantic>=2.13.2",
+    "pydantic>=2.13.3",
     "asyncio-throttle>=1.0.2",
     "python-dotenv>=1.2.2",
     "uvicorn>=0.44.0",
@@ -28,7 +28,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "black>=26.3.1",
     "isort>=8.0.1",
-    "mypy>=1.20.1",
+    "mypy>=1.20.2",
     "pip-audit>=2.10.0",
 ]
 


### PR DESCRIPTION
## Summary

- Bumped minimum version constraints in `pyproject.toml` to pick up latest stable releases
- CVE-2026-3219 identified in `pip` itself (installer tool, not a project dependency) — resolved by upgrading pip to 26.1; no pyproject.toml change required for this CVE as pip is not a declared dependency

## CVEs Resolved

| Package | CVE | Severity | Description | Fix |
|---------|-----|----------|-------------|-----|
| `pip` | CVE-2026-3219 / GHSA-58qw-9mgm-455v | Medium | pip mishandles concatenated tar+ZIP files, allowing incorrect files to be installed | Upgraded `pip` 26.0.1 → 26.1 (environment-level fix; `pip` is not a declared project dependency) |

> **Note:** `pip-audit` reported no fixed version at time of initial scan, but upgrading to pip 26.1 resolved the finding in a subsequent scan.

## Dependencies Updated

| Package | Previous Minimum | New Minimum | Type |
|---------|-----------------|-------------|------|
| `pydantic` | `>=2.13.2` | `>=2.13.3` | Runtime |
| `mypy` | `>=1.20.1` | `>=1.20.2` | Dev |

## Verification Checklist

- [x] `pip-audit`: **No known vulnerabilities found** (post-upgrade)
- [x] `safety check`: **0 vulnerabilities reported** (124 packages scanned)
- [x] `black --check`: Passing (5 files unchanged)
- [x] `isort --check-only`: Passing
- [x] `mypy`: Pre-existing type errors only (48 errors in 3 files, not introduced by this PR)
- [x] `pytest`: **50 passed, 1 skipped** (1 skipped = live Jira connection test, expected in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Pydantic dependency to version 2.13.3.
  * Updated mypy development dependency to version 1.20.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->