### PR TITLE
ACM-37424: Rename work_type to activity_type and fix activity_type ID handling on update

### DIFF
--- a/.cursor/commands/jira-create.md
+++ b/.cursor/commands/jira-create.md
@@ -20,7 +20,7 @@ Type `/jira-create` or `/jira create` to start the interactive issue creation pr
 - Labels (including Train-* labels)
 - Fix version/target release
 - Assignee (suggests "assign to me")
-- Work type
+- Activity Type
 - Original time estimate
 - Story points
 - Target Start (defaults to today's date)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JIRA_EMAIL=<your-email>@redhat.com
 
 4. **Reconnect** — In Claude Code run `/mcp` to reconnect, or restart your client (Cursor, Gemini CLI, etc.)
 
-All custom field IDs and work type IDs have been updated in the code. No other changes needed.
+All custom field IDs and activity type IDs have been updated in the code. No other changes needed.
 
 ## Table of Contents
 
@@ -591,7 +591,7 @@ The `/jira-create` command provides a guided, interactive flow for creating Jira
 
 1. **Issue Type** — Select from Story, Bug, Task, Spike, Feature, Epic, or Sub-task
 2. **Specialist Agent** — A specialist agent (e.g., `story-specialist`, `bug-specialist`) is launched to help craft the summary and description based on the issue type
-3. **Core Fields** — Priority, Work Type, Original Estimate, Story Points
+3. **Core Fields** — Priority, Activity Type, Original Estimate, Story Points
 4. **Categorization** — Component, Labels, Target Version
 5. **Parent / Linking** — Link to a parent issue or related issues
 6. **Confirmation** — Review all fields before creation

--- a/doc/COMPONENT_ALIASES.md
+++ b/doc/COMPONENT_ALIASES.md
@@ -59,7 +59,7 @@ create_issue(
     description="The login button is not responding to clicks",
     issue_type="Bug",
     priority="High",
-    work_type="10610",
+    activity_type="10610",
     due_date="2025-12-31",
     components=["ui", "be"]  # Will resolve to ["User Interface", "Backend Services"]
 )
@@ -72,7 +72,7 @@ create_issue(
 update_issue(
     issue_key="ACM-123",
     priority="High",
-    work_type="10610",
+    activity_type="10610",
     due_date="2025-12-31",
     components=["ui", "db"]  # Mix of aliases
 )
@@ -88,7 +88,7 @@ create_issue(
     description="Optimize database queries for better performance",
     issue_type="Task",
     priority="Medium",
-    work_type="10610",
+    activity_type="10610",
     due_date="2025-12-31",
     components=["db", "Performance Testing"]  # Alias + actual name
 )
@@ -281,7 +281,7 @@ create_issue(
     description="Addon fails to deploy on new clusters",
     issue_type="Bug",
     priority="High",
-    work_type="10607",  # Incident & Support
+    activity_type="10607",  # Incident & Support
     due_date="2025-11-30",
     components=["addon", "hcp"]  # Resolves to actual component names
 )
@@ -304,7 +304,7 @@ create_issue(
     description="Response times increased by 50% in production",
     issue_type="Bug",
     priority="Critical",
-    work_type="10607",
+    activity_type="10607",
     due_date="2025-11-20",
     components=["fe", "api", "db"]  # Three components with short aliases
 )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,7 +55,7 @@ These are hardcoded in `server.py` — if migrating to a different Jira instance
 | Field | Jira ID |
 |---|---|
 | Target Version | `customfield_10855` |
-| Work Type (Activity Type) | `customfield_10464` |
+| Activity Type (formerly Work Type) | `customfield_10464` |
 | Target Start | `customfield_10022` |
 | Target End | `customfield_10023` |
 | Story Points | `customfield_10028` |

--- a/jira_mcp_server/client.py
+++ b/jira_mcp_server/client.py
@@ -849,9 +849,9 @@ class JiraClient:
             "target_version": [
                 v.name for v in getattr(issue.fields, "customfield_10855", []) or []
             ],  # Target Version custom field
-            "work_type": self._extract_custom_field_value(
+            "activity_type": self._extract_custom_field_value(
                 getattr(issue.fields, "customfield_10464", None)
-            ),  # Activity Type (formerly Work Type)
+            ),  # Activity Type
             "security_level": (
                 getattr(issue.fields.security, "name", None)
                 if getattr(issue.fields, "security", None)

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -56,17 +56,25 @@ def _resolve_activity_type(value: str) -> str:
 
     Accepts either the human-readable label (e.g. "Security & Compliance") or
     the numeric option ID (e.g. "10609") and always returns the numeric ID
-    string expected by Jira's API. If the value is not a recognized label, it
-    is assumed to already be a numeric ID (or unknown) and is passed through
-    unchanged.
+    string expected by Jira's API. If the value is neither a recognized label
+    nor a numeric ID, a ValueError is raised so the caller doesn't silently
+    submit an invalid value to Jira.
 
     Args:
         value: The activity type label or numeric ID
 
     Returns:
         The numeric ID string
+
+    Raises:
+        ValueError: If the value is not a recognized label or numeric ID
     """
-    return ACTIVITY_TYPE_MAP.get(value, str(value))
+    if value in ACTIVITY_TYPE_MAP:
+        return ACTIVITY_TYPE_MAP[value]
+    if value.lstrip("-").isdigit():
+        return value
+    supported = ", ".join(ACTIVITY_TYPE_MAP.keys())
+    raise ValueError(f"Unknown Activity Type: {value!r}. Supported labels: {supported}")
 
 
 def _validate_git_commit_sha(sha: str) -> None:

--- a/jira_mcp_server/server.py
+++ b/jira_mcp_server/server.py
@@ -36,6 +36,38 @@ logger = logging.getLogger(__name__)
 # Any status not in this set will require fix_version before transitioning
 EARLY_STATUSES = {"new", "backlog", "in progress"}
 
+# Mapping of Activity Type (customfield_10464) labels to their numeric option IDs.
+# Jira's API requires the numeric ID when writing this field; reads return the
+# label string instead, so this map lets callers pass either form.
+ACTIVITY_TYPE_MAP = {
+    "None": "-1",
+    "Associate Wellness & Development": "10604",
+    "BU Features": "10605",
+    "Future Sustainability": "10606",
+    "Incidents & Support": "10607",
+    "Quality / Stability / Reliability": "10608",
+    "Security & Compliance": "10609",
+    "Product / Portfolio Work": "10610",
+}
+
+
+def _resolve_activity_type(value: str) -> str:
+    """Resolve an Activity Type label or numeric ID to a numeric ID string.
+
+    Accepts either the human-readable label (e.g. "Security & Compliance") or
+    the numeric option ID (e.g. "10609") and always returns the numeric ID
+    string expected by Jira's API. If the value is not a recognized label, it
+    is assumed to already be a numeric ID (or unknown) and is passed through
+    unchanged.
+
+    Args:
+        value: The activity type label or numeric ID
+
+    Returns:
+        The numeric ID string
+    """
+    return ACTIVITY_TYPE_MAP.get(value, str(value))
+
 
 def _validate_git_commit_sha(sha: str) -> None:
     """Validate that a git commit SHA is either 40 characters (SHA-1) or 64 characters (SHA-256).
@@ -95,7 +127,7 @@ class IssueResponse(BaseModel):
     url: str
     fix_versions: List[str]
     target_version: List[str]
-    work_type: Optional[str]
+    activity_type: Optional[str]
     security_level: Optional[str]
     due_date: Optional[str]
     target_start: Optional[str]
@@ -337,7 +369,7 @@ class JiraMCPServer:
             summary: str,
             description: str,
             priority: str = "Normal",
-            work_type: Optional[str] = None,
+            activity_type: Optional[str] = None,
             components: Optional[List[str]] = None,
             target_version: Optional[List[str]] = None,
             issue_type: str = "Task",
@@ -373,7 +405,7 @@ class JiraMCPServer:
                 labels: List of labels to add
                 fix_versions: List of fix version names (set when issue is closed)
                 target_version: List of target version names (set when issue is created)
-                work_type: Work type for the issue (STRONGLY RECOMMENDED). Available options:
+                activity_type: Activity Type for the issue (STRONGLY RECOMMENDED). Available options:
                     - **None** = -1
                     - **Associate Wellness & Development** = 10604
                     - **BU Features** = 10605
@@ -431,10 +463,10 @@ class JiraMCPServer:
                 fields["customfield_10855"] = [
                     {"name": version} for version in target_version
                 ]
-            if work_type:
+            if activity_type:
                 fields["customfield_10464"] = {
-                    "id": str(work_type)
-                }  # Activity Type (formerly Work Type)
+                    "id": _resolve_activity_type(activity_type)
+                }  # Activity Type
             if security_level:
                 fields["security"] = {"name": security_level}
             if due_date:
@@ -500,7 +532,7 @@ class JiraMCPServer:
         async def update_issue(
             issue_key: str,
             priority: Optional[str] = None,
-            work_type: Optional[str] = None,
+            activity_type: Optional[str] = None,
             components: Optional[List[str]] = None,
             due_date: Optional[str] = None,
             summary: Optional[str] = None,
@@ -530,7 +562,7 @@ class JiraMCPServer:
                 labels: New labels list
                 fix_versions: List of fix version names (set when issue is closed)
                 target_version: List of target version names (set when issue is created)
-                work_type: Work type for the issue (STRONGLY RECOMMENDED). Available options:
+                activity_type: Activity Type for the issue (STRONGLY RECOMMENDED). Available options:
                     - **None** = -1
                     - **Associate Wellness & Development** = 10604
                     - **BU Features** = 10605
@@ -576,10 +608,10 @@ class JiraMCPServer:
                 fields["customfield_10855"] = [
                     {"name": version} for version in target_version
                 ]
-            if work_type:
+            if activity_type:
                 fields["customfield_10464"] = {
-                    "id": str(work_type)
-                }  # Activity Type (formerly Work Type)
+                    "id": _resolve_activity_type(activity_type)
+                }  # Activity Type
             if security_level:
                 fields["security"] = {"name": security_level}
             if due_date:
@@ -1274,7 +1306,7 @@ class JiraMCPServer:
 - **Components:** {', '.join(issue['components']) if issue['components'] else 'None'}
 - **Fix Versions:** {', '.join(issue['fix_versions']) if issue['fix_versions'] else 'None'}
 - **Target Version:** {', '.join(issue['target_version']) if issue['target_version'] else 'None'}
-- **Work Type:** {issue['work_type'] or 'None'}
+- **Activity Type:** {issue['activity_type'] or 'None'}
 - **Security Level:** {issue['security_level'] or 'None'}
 - **Due Date:** {issue['due_date'] or 'None'}
 - **Target Start:** {issue['target_start'] or 'None'}

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -128,10 +128,12 @@ class TestResolveActivityType:
     def test_numeric_id_passes_through(self):
         assert _resolve_activity_type("10609") == "10609"
 
-    def test_unknown_value_passes_through(self):
-        assert _resolve_activity_type("Not A Real Activity Type") == (
-            "Not A Real Activity Type"
-        )
+    def test_negative_numeric_id_passes_through(self):
+        assert _resolve_activity_type("-1") == "-1"
+
+    def test_unknown_value_raises(self):
+        with pytest.raises(ValueError, match="Unknown Activity Type"):
+            _resolve_activity_type("Not A Real Activity Type")
 
 
 # ─── create_issue ────────────────────────────────────────────────────────────
@@ -235,6 +237,24 @@ class TestCreateIssue:
 
         call_kwargs = server.client.create_issue.call_args.kwargs
         assert call_kwargs["customfield_10464"] == {"id": "10609"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_activity_type_raises(self, server):
+        server.client.create_issue = AsyncMock(return_value=FAKE_ISSUE)
+
+        async with Client(server.mcp) as client:
+            with pytest.raises(Exception):
+                await client.call_tool(
+                    "create_issue",
+                    {
+                        "project_key": "TEST",
+                        "summary": "Fix it",
+                        "description": "desc",
+                        "activity_type": "Not A Real Activity Type",
+                    },
+                )
+
+        server.client.create_issue.assert_not_called()
 
 
 # ─── update_issue ────────────────────────────────────────────────────────────

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -20,7 +20,11 @@ from unittest.mock import AsyncMock
 import pytest
 from fastmcp import Client
 
-from jira_mcp_server.server import JiraMCPServer, _validate_git_commit_sha
+from jira_mcp_server.server import (
+    JiraMCPServer,
+    _resolve_activity_type,
+    _validate_git_commit_sha,
+)
 
 # ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -49,7 +53,7 @@ FAKE_ISSUE = {
     "url": "https://test.atlassian.net/browse/TEST-1",
     "fix_versions": [],
     "target_version": [],
-    "work_type": None,
+    "activity_type": None,
     "security_level": None,
     "due_date": None,
     "target_start": None,
@@ -98,6 +102,36 @@ class TestValidateGitCommitSha:
     def test_non_hex_characters_raise(self):
         with pytest.raises(ValueError, match="hexadecimal"):
             _validate_git_commit_sha("z" * 40)
+
+
+# ─── _resolve_activity_type ──────────────────────────────────────────────────
+
+
+class TestResolveActivityType:
+    def test_label_resolves_to_numeric_id(self):
+        assert _resolve_activity_type("Security & Compliance") == "10609"
+
+    def test_all_known_labels_resolve(self):
+        expected = {
+            "None": "-1",
+            "Associate Wellness & Development": "10604",
+            "BU Features": "10605",
+            "Future Sustainability": "10606",
+            "Incidents & Support": "10607",
+            "Quality / Stability / Reliability": "10608",
+            "Security & Compliance": "10609",
+            "Product / Portfolio Work": "10610",
+        }
+        for label, numeric_id in expected.items():
+            assert _resolve_activity_type(label) == numeric_id
+
+    def test_numeric_id_passes_through(self):
+        assert _resolve_activity_type("10609") == "10609"
+
+    def test_unknown_value_passes_through(self):
+        assert _resolve_activity_type("Not A Real Activity Type") == (
+            "Not A Real Activity Type"
+        )
 
 
 # ─── create_issue ────────────────────────────────────────────────────────────
@@ -166,6 +200,42 @@ class TestCreateIssue:
                     },
                 )
 
+    @pytest.mark.asyncio
+    async def test_activity_type_label_resolved_to_numeric_id(self, server):
+        server.client.create_issue = AsyncMock(return_value=FAKE_ISSUE)
+
+        async with Client(server.mcp) as client:
+            await client.call_tool(
+                "create_issue",
+                {
+                    "project_key": "TEST",
+                    "summary": "Fix it",
+                    "description": "desc",
+                    "activity_type": "Security & Compliance",
+                },
+            )
+
+        call_kwargs = server.client.create_issue.call_args.kwargs
+        assert call_kwargs["customfield_10464"] == {"id": "10609"}
+
+    @pytest.mark.asyncio
+    async def test_activity_type_numeric_id_passthrough(self, server):
+        server.client.create_issue = AsyncMock(return_value=FAKE_ISSUE)
+
+        async with Client(server.mcp) as client:
+            await client.call_tool(
+                "create_issue",
+                {
+                    "project_key": "TEST",
+                    "summary": "Fix it",
+                    "description": "desc",
+                    "activity_type": "10609",
+                },
+            )
+
+        call_kwargs = server.client.create_issue.call_args.kwargs
+        assert call_kwargs["customfield_10464"] == {"id": "10609"}
+
 
 # ─── update_issue ────────────────────────────────────────────────────────────
 
@@ -190,6 +260,32 @@ class TestUpdateIssue:
         server.client.update_issue.assert_called_once()
         call_kwargs = server.client.update_issue.call_args
         assert call_kwargs[0][0] == "TEST-1"
+
+    @pytest.mark.asyncio
+    async def test_activity_type_label_resolved_to_numeric_id(self, server):
+        server.client.update_issue = AsyncMock(return_value=FAKE_ISSUE)
+
+        async with Client(server.mcp) as client:
+            await client.call_tool(
+                "update_issue",
+                {"issue_key": "TEST-1", "activity_type": "Security & Compliance"},
+            )
+
+        call_kwargs = server.client.update_issue.call_args.kwargs
+        assert call_kwargs["customfield_10464"] == {"id": "10609"}
+
+    @pytest.mark.asyncio
+    async def test_activity_type_numeric_id_passthrough(self, server):
+        server.client.update_issue = AsyncMock(return_value=FAKE_ISSUE)
+
+        async with Client(server.mcp) as client:
+            await client.call_tool(
+                "update_issue",
+                {"issue_key": "TEST-1", "activity_type": "10609"},
+            )
+
+        call_kwargs = server.client.update_issue.call_args.kwargs
+        assert call_kwargs["customfield_10464"] == {"id": "10609"}
 
 
 # ─── search_issues_by_team ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Renames the `work_type` parameter/field/output key to `activity_type` across
the codebase to match Jira's renamed `customfield_10464` ("Work Type" →
"Activity Type"), and fixes a bug found while testing `update_issue`.

## Changes

- Renamed `work_type` → `activity_type` in:
  - `jira_mcp_server/server.py` (`create_issue`, `update_issue`, docstrings,
    `IssueResponse` model, output formatting)
  - `jira_mcp_server/client.py` (extraction key from `customfield_10464`)
  - `tests/test_server_tools.py`
  - `README.md`, `docs/ARCHITECTURE.md`, `doc/COMPONENT_ALIASES.md`,
    `.cursor/commands/jira-create.md`

- **Bug fix:** `activity_type` requires the numeric option ID (e.g. `10609`)
  when writing via `create_issue`/`update_issue`, but reading an issue back
  returns the human-readable label (e.g. `"Security & Compliance"`). Passing
  the label back into `update_issue` silently failed. Added an
  `ACTIVITY_TYPE_MAP` dict and `_resolve_activity_type()` helper so both
  tools now accept either the numeric ID or the label string.

## Testing

- `make test` — 79 passed
- `make lint` (ruff) — clean
- `mypy jira_mcp_server/` — no issues
- `black` / `isort` — no changes needed
- Added unit tests for `_resolve_activity_type` (all 8 known labels, numeric
  passthrough, unknown-value passthrough) and integration tests confirming
  `create_issue`/`update_issue` resolve labels to numeric IDs on the wire.

Jira: ACM-37424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying an **Activity Type** when creating or updating issues.
  * **Activity Type** inputs now accept either labels or numeric IDs and are handled consistently.
  * Issue details now display **“Activity Type”**.
* **Bug Fixes**
  * Updated issue responses and workflows to use **Activity Type** consistently instead of the previous **Work Type**.
* **Tests**
  * Added automated coverage for Activity Type resolution and create/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->