### PR TITLE
chore: bump package version to 0.2.0

### DIFF
--- a/jira_mcp_server/__init__.py
+++ b/jira_mcp_server/__init__.py
@@ -16,4 +16,4 @@
 
 """Jira MCP Server - A Model Context Protocol server for local Jira instances."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jira-mcp-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for local Jira instances"
 authors = [
     {name = "Your Name", email = "your.email@example.com"},


### PR DESCRIPTION
## Summary
Bumps the package version in `pyproject.toml` and `jira_mcp_server/__init__.py` from `0.1.0` to `0.2.0` to match the `v0.2.0` tag/release that was just published, so the built wheel filename stays in sync with future release tags.

## Context
The `v0.2.0` GitHub release was cut from a tag, but the package `version` field wasn't bumped beforehand, so the release workflow built `jira_mcp_server-0.1.0-py3-none-any.whl` under the `v0.2.0` tag. This PR fixes the version going forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.2.0.
  * Aligned the displayed and published package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->