### PR TITLE
chore: bump package version to 0.2.1

### DIFF
--- a/jira_mcp_server/__init__.py
+++ b/jira_mcp_server/__init__.py
@@ -16,4 +16,4 @@
 
 """Jira MCP Server - A Model Context Protocol server for local Jira instances."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jira-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server for local Jira instances"
 authors = [
     {name = "Your Name", email = "your.email@example.com"},


### PR DESCRIPTION
## Summary
Bumps the package version in `pyproject.toml` and `jira_mcp_server/__init__.py` from `0.2.0` to `0.2.1` ahead of cutting the `v0.2.1` tag/release, so the built wheel version stays in sync with the release tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.2.0 to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->