### PR TITLE
ci(auto-merge-deps): match deps/ branches and automated-update label

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -26,15 +26,20 @@ jobs:
           set -euo pipefail
 
           # Only PRs authored by the trusted swarmer-jnpacker[bot] GitHub App
-          # identity, targeting main, on a dependency-update branch (created
-          # by the swarm-deps-agent bot), are eligible for auto-merge. Also
-          # require the PR to be mergeable and every non-tide check to have
-          # completed successfully (not just "at least one success" - a
-          # pending check must not count as passing).
-          prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable --jq '
+          # identity, targeting main, are eligible for auto-merge. In
+          # addition, the PR must either be on a dependency-update branch
+          # (created by the swarm-deps-agent bot) or carry the
+          # "automated-update" label. Also require the PR to be mergeable
+          # and every non-tide check to have completed successfully (not
+          # just "at least one success" - a pending check must not count as
+          # passing).
+          prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
             .[] | select(
               (.author.login == "swarmer-jnpacker[bot]") and
-              (.headRefName | test("^(fix|build)/(go|python)-deps-")) and
+              (
+                (.headRefName | test("^(fix|build|deps)/(go|python)-(deps|update)-")) or
+                (.labels // [] | any(.name == "automated-update"))
+              ) and
               (.mergeable == "MERGEABLE") and
               ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide")] as $checks |
                 ($checks | length > 0) and
@@ -82,6 +87,14 @@ jobs:
             pr_branch=$(echo "$pr_info" | jq -r '.headRefName')
             pr_head_oid=$(echo "$pr_info" | jq -r '.headRefOid')
 
+            # Note in the merge comment which eligibility path matched, so
+            # it's clear from the audit trail why the PR qualified.
+            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(go|python)-(deps|update)-"; then
+              pr_match_reason="branch: $pr_branch"
+            else
+              pr_match_reason="label: automated-update, branch: $pr_branch"
+            fi
+
             echo "Attempting to merge PR #$pr_number: $pr_title (branch: $pr_branch)"
 
             # --match-head-commit binds the merge to the exact commit that
@@ -97,12 +110,12 @@ jobs:
                 echo "Successfully merged PR #$pr_number"
                 merged_count=$((merged_count + 1))
 
-                gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: swarmer-jnpacker[bot], branch: $pr_branch)."
+                gh pr comment "$pr_number" --body "This PR was automatically merged because all checks passed and it matched the trusted dependency update pattern (author: swarmer-jnpacker[bot], $pr_match_reason)."
               else
                 echo "PR #$pr_number was queued for merge (state: $pr_state), not yet merged"
                 queued_count=$((queued_count + 1))
 
-                gh pr comment "$pr_number" --body "This PR passed all checks and matched the trusted dependency update pattern (author: swarmer-jnpacker[bot], branch: $pr_branch); it has been queued for merge."
+                gh pr comment "$pr_number" --body "This PR passed all checks and matched the trusted dependency update pattern (author: swarmer-jnpacker[bot], $pr_match_reason); it has been queued for merge."
               fi
             else
               echo "Failed to merge PR #$pr_number"
@@ -127,8 +140,9 @@ jobs:
           {
             echo "## Auto-merge workflow summary"
             echo ""
-            echo "Checked for dependency PRs authored by swarmer-jnpacker[bot] on branches"
-            echo "matching \`fix/{go,python}-deps-*\` or \`build/{go,python}-deps-*\` that have:"
+            echo "Checked for dependency PRs authored by swarmer-jnpacker[bot] that either match"
+            echo "branches like \`fix/{go,python}-deps-*\`, \`build/{go,python}-deps-*\`, or"
+            echo "\`deps/{go,python}-update-*\`, or carry the \`automated-update\` label, and have:"
             echo "- All status checks passing (SUCCESS)"
             echo "- Mergeable state (no conflicts)"
             echo ""


### PR DESCRIPTION
## Executive Summary
- The auto-merge eligibility check only matched bot branches named `fix/{go,python}-deps-*` or `build/{go,python}-deps-*`, so PRs from branches like `deps/python-update-20260810` were silently ignored.
- Widens the branch regex to accept a `deps/` prefix and `-update-` suffix, and adds an OR path so any bot PR carrying the `automated-update` label is eligible for auto-merge regardless of branch naming.

## Detailed Implementation Summary
- **File modified:** `.github/workflows/auto-merge-deps.yaml`
  - Widened branch regex: `^(fix|build)/(go|python)-deps-` → `^(fix|build|deps)/(go|python)-(deps|update)-`
  - Added `labels` to the `gh pr list --json` fields.
  - Added an OR clause in the `jq` eligibility filter: bot PRs with the `automated-update` label now qualify even if the branch name doesn't match the regex. Author check, mergeable state, and passing-checks requirements are unchanged and still apply on both paths.
  - Merge/queue PR comments now note which eligibility path matched (branch pattern vs. label) for audit clarity.
  - Updated the workflow summary step text to describe both paths.
- **Testing:** Validated YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`) and manually exercised the `jq` filter against 5 synthetic PR payloads (branch match, label match, no match, wrong author with label, and failing checks) — all resolved as expected.
- **Known gaps:** None. No production behavior changes beyond widening eligibility; existing branch patterns and author/check requirements remain enforced.

Jira: N/A (no ticket for this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated merging for eligible dependency updates targeting the main branch.
  * Added support for approved update branches and the `automated-update` label.
  * Merge notifications now indicate why an update qualified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->