### PR TITLE
ci(auto-merge-deps): compare check status case-insensitively

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -43,7 +43,9 @@ jobs:
               (.mergeable == "MERGEABLE") and
               ([.statusCheckRollup[] | select(.context != "tide" and .name != "tide")] as $checks |
                 ($checks | length > 0) and
-                ($checks | all(.state == "SUCCESS" or .conclusion == "SUCCESS")))
+                ($checks | all(
+                  ((.state // "" | ascii_upcase) == "SUCCESS") or
+                  ((.conclusion // "" | ascii_upcase) == "SUCCESS"))))
             )')
 
           if [ -z "$prs" ]; then


### PR DESCRIPTION
## Executive Summary
- PR #52 matched the branch/label eligibility rules added in #53 but was still never auto-merged (workflow run: https://github.com/stolostron/jira-mcp-server/actions/runs/31495608553/job/93792425913 logged "No PRs ready for auto-merge" despite all 7 of its check runs passing).
- Root cause: `gh pr list --json statusCheckRollup` returns check-run `conclusion` values in lowercase (`"success"`), but the eligibility filter only matched uppercase `"SUCCESS"`, so every check run failed the test and the PR was silently excluded.

## Detailed Implementation Summary
- **File modified:** `.github/workflows/auto-merge-deps.yaml`
  - Normalized the `.state` and `.conclusion` comparison with `ascii_upcase` before comparing to `"SUCCESS"`, so the check passes regardless of the casing `gh` returns (confirmed via REST API that PR #52's check runs report `"conclusion":"success"` in lowercase).
- **Testing:**
  - YAML validated: `python3 -c "import yaml; yaml.safe_load(...)"`
  - Manually exercised the updated `jq` filter against 5 synthetic payloads modeled on PR #52's real data (mixed-case conclusions `success`/`SUCCESS`/`Success`, a failing check, a pending/in-progress check, only the `tide` status present, and a legacy uppercase commit status) — all resolved correctly, including confirming the previously-broken mixed-case case now matches.
- **Known gaps:** None. This is a pure bug fix restoring the intended behavior from #53; no eligibility criteria were loosened beyond fixing the case-sensitivity bug.

Jira: N/A (no ticket for this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency update eligibility checks by handling status values consistently regardless of letter casing.
  * Prevented missing status information from causing incorrect eligibility decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->