### PR TITLE
ci(auto-merge-deps): accept gh's app/ author login format

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -26,16 +26,19 @@ jobs:
           set -euo pipefail
 
           # Only PRs authored by the trusted swarmer-jnpacker[bot] GitHub App
-          # identity, targeting main, are eligible for auto-merge. In
-          # addition, the PR must either be on a dependency-update branch
-          # (created by the swarm-deps-agent bot) or carry the
+          # identity, targeting main, are eligible for auto-merge. gh pr
+          # list's GraphQL-backed --json author renders bot logins as
+          # "app/swarmer-jnpacker" (not the "swarmer-jnpacker[bot]" form
+          # used by the REST API and web UI), so match both spellings.
+          # In addition, the PR must either be on a dependency-update
+          # branch (created by the swarm-deps-agent bot) or carry the
           # "automated-update" label. Also require the PR to be mergeable
           # and every non-tide check to have completed successfully (not
           # just "at least one success" - a pending check must not count as
           # passing).
           prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
             .[] | select(
-              (.author.login == "swarmer-jnpacker[bot]") and
+              (.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker") and
               (
                 (.headRefName | test("^(fix|build|deps)/(go|python)-(deps|update)-")) or
                 (.labels // [] | any(.name == "automated-update"))


### PR DESCRIPTION
## Executive Summary
- PR #52 was still excluded from auto-merge after #53 (branch/label match) and #54 (case-insensitive status check) both merged — a local `gh pr list --repo stolostron/jira-mcp-server --json author,...` dump revealed the true root cause.
- `gh pr list --json author` renders bot logins via the GraphQL API as `"app/swarmer-jnpacker"`, not the `"swarmer-jnpacker[bot]"` form used by the REST API and GitHub's web UI. The very first condition in the eligibility filter (`.author.login == "swarmer-jnpacker[bot]"`) never matched, so PR #52 was excluded before any of the branch/label/status logic even ran.

## Detailed Implementation Summary
- **File modified:** `.github/workflows/auto-merge-deps.yaml`
  - Author check now accepts either login spelling: `.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker"`.
  - Updated the inline comment to document why both forms are needed.
- **Testing:**
  - YAML validated: `python3 -c "import yaml; yaml.safe_load(...)"`.
  - Ran the `jq` filter against the exact real PR #52 payload (captured locally via `gh pr list --repo stolostron/jira-mcp-server --json number,author,headRefName,mergeable,labels,statusCheckRollup`) — PR #52 now matches.
  - Re-ran the existing regression suite (branch match, label match, non-bot author + label, no branch/label match, failing check) plus a new case for the REST-style `swarmer-jnpacker[bot]` login — all resolve correctly with no regressions.
- **Known gaps:** None. This closes out the auto-merge eligibility gap across all three root causes found for PR #52 (branch naming, status casing, author login format).

Jira: N/A (no ticket for this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency update handling by recognizing both supported author login formats.
  * Added clarification on how author identities appear in pull request listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->