### PR TITLE
ci(auto-merge-deps): remove debug dump, PR #52 confirmed auto-merged

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -25,33 +25,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # --- TEMPORARY DEBUG: dump raw gh pr list data for the first open
-          # PR so we can see exactly what the workflow's GH_TOKEN observes
-          # (author login format, mergeable state, labels, check states).
-          # This diverges from what a personal PAT sees locally against the
-          # same PR, which is why the eligibility filter below has not been
-          # matching despite local jq tests passing. Remove this block once
-          # the real mismatch is identified and fixed.
-          echo "=== DEBUG: raw gh pr list output (first open PR) ==="
-          gh pr list --state open --base main --limit 1 \
-            --json number,author,headRefName,mergeable,labels,statusCheckRollup \
-            | jq '.[0] | {
-                number,
-                author,
-                headRefName,
-                mergeable,
-                labels: [.labels[]?.name],
-                checks: [.statusCheckRollup[] | {
-                  name: (.name // .context),
-                  type: .__typename,
-                  state,
-                  conclusion,
-                  status
-                }]
-              }'
-          echo "=== END DEBUG ==="
-          # --- END TEMPORARY DEBUG ---
-
           # Only PRs authored by the trusted swarmer-jnpacker[bot] GitHub App
           # identity, targeting main, are eligible for auto-merge. gh pr
           # list's GraphQL-backed --json author renders bot logins as
@@ -62,7 +35,10 @@ jobs:
           # "automated-update" label. Also require the PR to be mergeable
           # and every non-tide check to have completed successfully (not
           # just "at least one success" - a pending check must not count as
-          # passing).
+          # passing). Note: GitHub computes `mergeable` asynchronously, so
+          # a PR can transiently report "UNKNOWN" on one API call and
+          # "MERGEABLE" moments later once GitHub finishes the check - this
+          # is expected and not something to special-case here.
           prs=$(gh pr list --state open --base main --limit 100 --json number,title,url,author,headRefName,headRefOid,statusCheckRollup,mergeable,labels --jq '
             .[] | select(
               (.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker") and


### PR DESCRIPTION
## Executive Summary
- Follow-up to #56. The debug dump added by #56 merged and ran successfully, confirming PR #52 was auto-merged by `github-actions[bot]` at `2026-08-11T13:45:11Z` — but PR #56 itself was merged before this cleanup commit could be included in it (the commit was pushed to the same fork branch after #56 already closed), so `main` still carries the now-unneeded debug block. This PR removes it.
- The debug snapshot showed `mergeable: "UNKNOWN"` on one `gh pr list` call, but the actual eligibility filter's separate `gh pr list` call (made moments later in the same step) saw `MERGEABLE` and correctly selected PR #52 — expected async behavior (GitHub computes `mergeable` in the background), not a bug. All three prior fixes (#53 branch/label, #54 status casing, #55 author login format) were correct and combined to make the eligibility check pass.

## Detailed Implementation Summary
- **File modified:** `.github/workflows/auto-merge-deps.yaml`
  - Removed the temporary debug block introduced in #56.
  - Added a short comment near the `mergeable` check noting that GitHub computes it asynchronously and a transient `UNKNOWN` between two back-to-back API calls in the same step is expected, not an error condition — this documents the exact behavior that caused apparent confusion during diagnosis.
- **Evidence:** Actions log from the diagnostic run (via #56) showed:
  ```
  === DEBUG: raw gh pr list output (first open PR) ===
  { "number": 52, "author": {"login": "app/swarmer-jnpacker", ...}, "mergeable": "UNKNOWN", ... "checks": [...all SUCCESS...] }
  === END DEBUG ===
  Found PRs ready for auto-merge:
  52
  ```
  PR #52 (`stolostron/jira-mcp-server#52`) is `merged: true`, `merged_by: "github-actions[bot]"`.
- **Testing:** YAML validated: `python3 -c "import yaml; yaml.safe_load(...)"`. Diff confirmed to be a clean removal of only the debug block plus the explanatory comment addition, no other logic changes.
- **Known gaps:** None. This closes out FLD-121 AC #4 ("First scheduled run correctly identifies and squash-merges an eligible PR with all checks passing").

Jira: FLD-121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance explaining that pull-request mergeability may briefly appear as unknown while checks are being calculated.

* **Chores**
  * Removed temporary diagnostic output from the automated dependency merge workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->