### PR TITLE
ci: broaden branch-pattern regex for deps-&lt;lang&gt;-update-&lt;date&gt; format

### DIFF
--- a/.github/workflows/auto-merge-deps.yaml
+++ b/.github/workflows/auto-merge-deps.yaml
@@ -43,7 +43,7 @@ jobs:
             .[] | select(
               (.author.login == "swarmer-jnpacker[bot]" or .author.login == "app/swarmer-jnpacker") and
               (
-                (.headRefName | test("^(fix|build|deps)/(go|python)-(deps|update)-")) or
+                (.headRefName | test("^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-")) or
                 (.labels // [] | any(.name == "automated-update"))
               ) and
               (.mergeable == "MERGEABLE") and
@@ -97,7 +97,7 @@ jobs:
 
             # Note in the merge comment which eligibility path matched, so
             # it's clear from the audit trail why the PR qualified.
-            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(go|python)-(deps|update)-"; then
+            if echo "$pr_branch" | grep -qE "^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-"; then
               pr_match_reason="branch: $pr_branch"
             else
               pr_match_reason="label: automated-update, branch: $pr_branch"
@@ -149,8 +149,9 @@ jobs:
             echo "## Auto-merge workflow summary"
             echo ""
             echo "Checked for dependency PRs authored by swarmer-jnpacker[bot] that either match"
-            echo "branches like \`fix/{go,python}-deps-*\`, \`build/{go,python}-deps-*\`, or"
-            echo "\`deps/{go,python}-update-*\`, or carry the \`automated-update\` label, and have:"
+            echo "branches matching \`(fix|build|deps)/[deps-]{go,python}[-deps][-update]-*\`"
+            echo "(the deps- prefix, -deps suffix, and -update suffix are each optional), or"
+            echo "carry the \`automated-update\` label, and have:"
             echo "- All status checks passing (SUCCESS)"
             echo "- Mergeable state (no conflicts)"
             echo ""


### PR DESCRIPTION
The CVE scan orchestrator generates branches like `build/deps-python-update-20260810`, where `deps` precedes the language and both `deps` and `update` segments are independently optional. The previous regex `^(fix|build|deps)/(go|python)-(deps|update)-` required the language to immediately follow the prefix and exactly one of `deps`/`update` to follow the language, so it didn't match this format — a real, eligible auto-merge PR would have been silently skipped.

**New pattern:** `^(fix|build|deps)/(deps-)?(go|python)(-deps)?(-update)?-`
- optional `deps-` before the language
- optional `-deps` and/or `-update` after the language

Matches all known formats:
- `fix/go-deps-*`
- `build/python-deps-*`
- `deps/go-update-*`
- `build/deps-python-update-*` (the new one)

Applied to both the `jq test()` eligibility check and the `grep -qE` match-reason classification (used for the merge/queue comment audit trail), and updated the human-readable summary text to match.

This same fix has also been rolled out to `gcal-mcp-server`, `gdrive-mcp-server`, `gmail-mcp-server`, `gtasks-mcp-server`, `stolostron/agent-swarm`, `stolostron/api-documentation`, `stolostron/maestro`, and the canonical templates in `OpenShift-Fleet/agentic-sdlc`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency update handling for Go and Python branches.
  * Dependency update pull requests with supported prefixes and suffixes are now recognized correctly for eligibility checks and merge reporting.
  * Updated workflow summaries to accurately describe the supported branch naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->